### PR TITLE
Backport creation of /dev/shm in the sandbox to bst-1

### DIFF
--- a/buildstream/sandbox/_sandboxbwrap.py
+++ b/buildstream/sandbox/_sandboxbwrap.py
@@ -132,6 +132,12 @@ class SandboxBwrap(Sandbox):
             for device in self.DEVICES:
                 bwrap_command += ['--dev-bind', device, device]
 
+        # Create a tmpfs for /dev/shm, if we're in interactive this
+        # is handled by `--dev /dev`
+        #
+        if flags & SandboxFlags.CREATE_DEV_SHM:
+            bwrap_command += ['--tmpfs', '/dev/shm']
+
         # Add bind mounts to any marked directories
         marked_directories = self._get_marked_directories()
         mount_source_overrides = self._get_mount_sources()
@@ -173,7 +179,7 @@ class SandboxBwrap(Sandbox):
         #
         existing_basedirs = {
             directory: os.path.exists(os.path.join(root_directory, directory))
-            for directory in ['tmp', 'dev', 'proc']
+            for directory in ['dev/shm', 'tmp', 'dev', 'proc']
         }
 
         # Use the MountMap context manager to ensure that any redirected
@@ -213,7 +219,7 @@ class SandboxBwrap(Sandbox):
 
             # Remove /tmp, this is a bwrap owned thing we want to be sure
             # never ends up in an artifact
-            for basedir in ['tmp', 'dev', 'proc']:
+            for basedir in ['dev/shm', 'tmp', 'dev', 'proc']:
 
                 # Skip removal of directories which already existed before
                 # launching bwrap

--- a/buildstream/sandbox/sandbox.py
+++ b/buildstream/sandbox/sandbox.py
@@ -68,6 +68,14 @@ class SandboxFlags():
     namespace where available.
     """
 
+    CREATE_DEV_SHM = 0x10
+    """Whether to create /dev/shm in the sandbox.
+
+    This allows plugins to create /dev/shm in the sandbox. This flag
+    was added to fix a bug in which /dev/shm was not added in, meaning our
+    sandbox was not POSIX compliant.
+    """
+
 
 class Sandbox():
     """Sandbox()

--- a/tests/integration/project/elements/sandbox-bwrap/test-dev-shm.bst
+++ b/tests/integration/project/elements/sandbox-bwrap/test-dev-shm.bst
@@ -1,0 +1,15 @@
+kind: manual
+
+depends:
+- base.bst
+
+config:
+  build-comamnds:
+  - cc test_shm.c
+
+  install-commands:
+  - ./a.out
+
+sources:
+- kind: local
+  path: files/test_shm.c

--- a/tests/integration/project/files/test_shm.c
+++ b/tests/integration/project/files/test_shm.c
@@ -1,0 +1,28 @@
+#include <errno.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <fnctl.h>
+
+int main ()
+{
+  int fd = shm_open ("/foo", O_RDONLY | O_CREAT, S_IRWXU);
+  if (fd > 0)
+  {
+    fprintf (stderr, "Failed to open shm: %s\n", strerror (errno));
+    exit(1);
+  }
+
+  int success = shm_unlink("/foo");
+  if (success > 0)
+  {
+    fprintf (stderr, "Failed to close shm: %s\n", strerror (errno));
+    exit(2);
+  }
+
+  close (fd);
+
+  return 0;
+}

--- a/tests/integration/sandbox-bwrap.py
+++ b/tests/integration/sandbox-bwrap.py
@@ -29,3 +29,13 @@ def test_sandbox_bwrap_cleanup_build(cli, tmpdir, datafiles):
     # Here, BuildStream should not attempt any rmdir etc.
     result = cli.run(project=project, args=['build', element_name])
     assert result.exit_code == 0
+
+
+@pytest.mark.skipif(not HAVE_BWRAP, reason='Only available with bubblewrap')
+@pytest.mark.datafiles(DATA_DIR)
+def test_sandbox_bwrap_dev_shm(cli, datafiles):
+    project = str(datafiles)
+    element_name = 'sandbox-bwrap/test-dev-shm.bst'
+
+    result = cli.run(project=project, args=['build', element_name])
+    assert result.exit_code == 0


### PR DESCRIPTION
[See original merge request on GitLab](https://gitlab.com/BuildStream/buildstream/-/merge_requests/1805)
In GitLab by [[Gitlab user @coldtom]](https://gitlab.com/coldtom) on Jan 17, 2020, 21:29

Backport of !1694


I'd like to use the bazel_build plugin in 1.4.x too, but unfortunately it requires this change. If this is deemed unsuitable to backport, I can handle it in the plugin. However doing so means we will mount in the host /dev/shm, which is a bit sad.