### PR TITLE
element.py: make BST_STRICT_REBUILD part of the cache key

### DIFF
--- a/src/buildstream/element.py
+++ b/src/buildstream/element.py
@@ -2048,6 +2048,7 @@ class Element(Plugin):
                 "element-plugin-key": self.get_unique_key(),
                 "element-plugin-name": self.get_kind(),
                 "element-plugin-version": self.BST_ARTIFACT_VERSION,
+                "element-strict-rebuild": self.BST_STRICT_REBUILD,
                 "sandbox": self.__sandbox_config.get_unique_key(),
                 "environment": cache_env,
                 "public": self.__public.strip_node_info(),


### PR DESCRIPTION
[See original merge request on GitLab](https://gitlab.com/BuildStream/buildstream/-/merge_requests/1895)
In GitLab by [[Gitlab user @abderrahimk]](https://gitlab.com/abderrahimk) on May 4, 2020, 11:13

## Description

Add the value of BST_STRICT_REBUILD to the cache key. This prevents confusing situations like #1270.


This merge request,  when approved, will close: #1270

----