### PR TITLE
WIP: [1.4] Allow junctions to inject dependencies from current project to junctioned one

### DIFF
--- a/buildstream/plugins/elements/junction.py
+++ b/buildstream/plugins/elements/junction.py
@@ -142,6 +142,7 @@ class JunctionElement(Element):
     def configure(self, node):
         self.path = self.node_get_member(node, str, 'path', default='')
         self.options = self.node_get_member(node, Mapping, 'options', default={})
+        self.replacements = self.node_get_member(node, Mapping, 'replacements', default={})
 
     def preflight(self):
         pass

--- a/tests/loader/junctions.py
+++ b/tests/loader/junctions.py
@@ -330,3 +330,19 @@ def test_build_git_cross_junction_names(cli, tmpdir, datafiles):
 
     # Check that the checkout contains the expected files from both projects
     assert(os.path.exists(os.path.join(checkoutdir, 'base.txt')))
+
+
+@pytest.mark.datafiles(DATA_DIR)
+def test_replacements(cli, tmpdir, datafiles):
+    project = os.path.join(str(datafiles), "replacements")
+    copy_subprojects(project, datafiles, ["replacements-base"])
+    checkoutdir = os.path.join(str(tmpdir), "checkout")
+
+    # Build, checkout
+    result = cli.run(project=project, args=["build", "stack.bst"])
+    result.assert_success()
+    result = cli.run(project=project, args=["checkout", "stack.bst", checkoutdir])
+    result.assert_success()
+
+    assert os.path.exists(os.path.join(checkoutdir, "destination/injected.txt"))
+    assert not os.path.exists(os.path.join(checkoutdir, "original.txt"))

--- a/tests/loader/junctions/replacements-base/a.bst
+++ b/tests/loader/junctions/replacements-base/a.bst
@@ -1,0 +1,4 @@
+kind: import
+sources:
+- kind: local
+  path: original.txt

--- a/tests/loader/junctions/replacements-base/compose.bst
+++ b/tests/loader/junctions/replacements-base/compose.bst
@@ -1,0 +1,3 @@
+kind: compose
+build-depends:
+- a.bst

--- a/tests/loader/junctions/replacements-base/original.txt
+++ b/tests/loader/junctions/replacements-base/original.txt
@@ -1,0 +1,1 @@
+Original

--- a/tests/loader/junctions/replacements-base/project.conf
+++ b/tests/loader/junctions/replacements-base/project.conf
@@ -1,0 +1,1 @@
+name: replacements-base

--- a/tests/loader/junctions/replacements/base.bst
+++ b/tests/loader/junctions/replacements/base.bst
@@ -1,0 +1,7 @@
+kind: junction
+config:
+  replacements:
+    a.bst: injected.bst
+sources:
+- kind: local
+  path: replacements-base

--- a/tests/loader/junctions/replacements/injected.bst
+++ b/tests/loader/junctions/replacements/injected.bst
@@ -1,0 +1,6 @@
+kind: import
+config:
+  target: "%{dest}"
+sources:
+- kind: local
+  path: injected.txt

--- a/tests/loader/junctions/replacements/injected.txt
+++ b/tests/loader/junctions/replacements/injected.txt
@@ -1,0 +1,1 @@
+Injected

--- a/tests/loader/junctions/replacements/project.conf
+++ b/tests/loader/junctions/replacements/project.conf
@@ -1,0 +1,5 @@
+name: replacements
+
+variables:
+  # This variable is not defined in the junctioned project
+  dest: "/destination"

--- a/tests/loader/junctions/replacements/stack.bst
+++ b/tests/loader/junctions/replacements/stack.bst
@@ -1,0 +1,3 @@
+kind: stack
+runtime-depends:
+- base.bst:compose.bst


### PR DESCRIPTION
[See original merge request on GitLab](https://gitlab.com/BuildStream/buildstream/-/merge_requests/1914)
In GitLab by [[Gitlab user @valentindavid]](https://gitlab.com/valentindavid) on May 10, 2020, 17:21

ME for master: !1913

There are cases where downstream projects want to overwrite upstream
elements.

So far, either the downstream project just allows overlaps and hopes
that ABI is compatible. There are also files left from original
elements when not overwritten.

Or downstream adds an "overlay" with local source to the
junctions. However on the latter, elements in the overlay are
considered as part of upstream, which means in cannot depend on
element outside of upstream (unless cyclic junction maybe?).

Here we add a feature to junctions to allow injecting elements from
current project to junctions.

This is useful for example in the case of GNOME SDK needing to override
GLib, GObjectIntrospection, libsoup, etc. from Freedesktop SDK, and avoid hacks

See https://gitlab.gnome.org/GNOME/gnome-build-meta/-/merge_requests/658