### PR TITLE
Do not use a sandbox when not required for checkout

### DIFF
--- a/src/buildstream/buildelement.py
+++ b/src/buildstream/buildelement.py
@@ -222,7 +222,7 @@ class BuildElement(Element):
 
         # Stage deps in the sandbox root
         with self.timed_activity("Staging dependencies", silent_nested=True):
-            self.stage_dependency_artifacts(sandbox, Scope.BUILD)
+            self.stage_dependency_artifacts(sandbox.get_virtual_directory(), Scope.BUILD)
 
         # Run any integration commands provided by the dependencies
         # once they are all staged and ready

--- a/src/buildstream/element.py
+++ b/src/buildstream/element.py
@@ -609,7 +609,7 @@ class Element(Plugin):
 
     def stage_artifact(
         self,
-        sandbox: "Sandbox",
+        vbasedir: "Directory",
         *,
         path: str = None,
         include: Optional[List[str]] = None,
@@ -668,7 +668,6 @@ class Element(Plugin):
 
             # Hard link it into the staging area
             #
-            vbasedir = sandbox.get_virtual_directory()
             vstagedir = vbasedir if path is None else vbasedir.descend(*path.lstrip(os.sep).split(os.sep), create=True)
 
             split_filter = self.__split_filter_func(include, exclude, orphans)
@@ -681,7 +680,7 @@ class Element(Plugin):
 
     def stage_dependency_artifacts(
         self,
-        sandbox: "Sandbox",
+        vbasedir: "Directory",
         scope: Scope,
         *,
         path: str = None,
@@ -714,7 +713,7 @@ class Element(Plugin):
         files_written = {}  # type: Dict[str, List[str]]
 
         for dep in self.dependencies(scope):
-            result = dep.stage_artifact(sandbox, path=path, include=include, exclude=exclude, orphans=orphans)
+            result = dep.stage_artifact(vbasedir, path=path, include=include, exclude=exclude, orphans=orphans)
             if result.overwritten:
                 for overwrite in result.overwritten:
                     # Completely new overwrite
@@ -1286,7 +1285,7 @@ class Element(Plugin):
             else:
                 # Stage deps in the sandbox root
                 with self.timed_activity("Staging dependencies", silent_nested=True):
-                    self.stage_dependency_artifacts(sandbox, scope)
+                    self.stage_dependency_artifacts(sandbox.get_virtual_directory(), scope)
 
                 # Run any integration commands provided by the dependencies
                 # once they are all staged and ready


### PR DESCRIPTION
[See original merge request on GitLab](https://gitlab.com/BuildStream/buildstream/-/merge_requests/1983)
In GitLab by [[Gitlab user @willsalmon]](https://gitlab.com/willsalmon) on Jul 3, 2020, 18:45

## Description

Even tho a sandbox is not required when we checkout without integration eg.

```
bst -o target_board rpi3 -o target_arch aarch64 artifact checkout --no-integrate deploy/image.bst
```

A sandbox is still setup which means that while bst can pull a artefact from a different architecture the artefact can not be checked out.

## Proposed changes

The key code path is `stage_dependency_artifacts` which takes a sandbox but then only uses the vdir from that sandbox. by changing this function to take only the vdir then it can be called without a sandbox and we can then checkout artefacts without needing the sandbox.