### PR TITLE
Draft: utils.py: Remove the (?ms) switch at the start of _glob2re

### DIFF
--- a/src/buildstream/utils.py
+++ b/src/buildstream/utils.py
@@ -1425,7 +1425,7 @@ def _call(*popenargs, terminate=False, **kwargs):
 #
 def _glob2re(pat):
     i, n = 0, len(pat)
-    res = "(?ms)"
+    res = ""
     while i < n:
         c = pat[i]
         i = i + 1


### PR DESCRIPTION
[See original merge request on GitLab](https://gitlab.com/BuildStream/buildstream/-/merge_requests/2047)
In GitLab by [[Gitlab user @BenjaminSchubert]](https://gitlab.com/BenjaminSchubert) on Aug 28, 2020, 15:00

The ?ms switch stands for multiline output.

This switch is used nowhere in our codebase.

It also is problematic in multiple places where its use is deprecated since python 3.7,
as now they need to be at the start of an expression, which is not the
case in all the calls to it that we are doing.

If someone wants the same functionality, they should add it explictely
after calling _glob2re

## TODO

Still need to add a test to see how BuildStream behaves with split files that have such characters in them