### PR TITLE
Draft: Simplify `bst shell` implementation

### DIFF
--- a/man/bst-artifact-checkout.1
+++ b/man/bst-artifact-checkout.1
@@ -1,4 +1,4 @@
-.TH "BST ARTIFACT CHECKOUT" "1" "2020-08-13" "" "bst artifact checkout Manual"
+.TH "BST ARTIFACT CHECKOUT" "1" "2020-10-07" "" "bst artifact checkout Manual"
 .SH NAME
 bst\-artifact\-checkout \- Checkout contents of an artifact
 .SH SYNOPSIS

--- a/man/bst-artifact-delete.1
+++ b/man/bst-artifact-delete.1
@@ -1,4 +1,4 @@
-.TH "BST ARTIFACT DELETE" "1" "2020-08-13" "" "bst artifact delete Manual"
+.TH "BST ARTIFACT DELETE" "1" "2020-10-07" "" "bst artifact delete Manual"
 .SH NAME
 bst\-artifact\-delete \- Remove artifacts from the local cache
 .SH SYNOPSIS

--- a/man/bst-artifact-list-contents.1
+++ b/man/bst-artifact-list-contents.1
@@ -1,4 +1,4 @@
-.TH "BST ARTIFACT LIST-CONTENTS" "1" "2020-08-13" "" "bst artifact list-contents Manual"
+.TH "BST ARTIFACT LIST-CONTENTS" "1" "2020-10-07" "" "bst artifact list-contents Manual"
 .SH NAME
 bst\-artifact\-list-contents \- List the contents of an artifact
 .SH SYNOPSIS

--- a/man/bst-artifact-log.1
+++ b/man/bst-artifact-log.1
@@ -1,4 +1,4 @@
-.TH "BST ARTIFACT LOG" "1" "2020-08-13" "" "bst artifact log Manual"
+.TH "BST ARTIFACT LOG" "1" "2020-10-07" "" "bst artifact log Manual"
 .SH NAME
 bst\-artifact\-log \- Show logs of artifacts
 .SH SYNOPSIS

--- a/man/bst-artifact-pull.1
+++ b/man/bst-artifact-pull.1
@@ -1,4 +1,4 @@
-.TH "BST ARTIFACT PULL" "1" "2020-08-13" "" "bst artifact pull Manual"
+.TH "BST ARTIFACT PULL" "1" "2020-10-07" "" "bst artifact pull Manual"
 .SH NAME
 bst\-artifact\-pull \- Pull a built artifact
 .SH SYNOPSIS

--- a/man/bst-artifact-push.1
+++ b/man/bst-artifact-push.1
@@ -1,4 +1,4 @@
-.TH "BST ARTIFACT PUSH" "1" "2020-08-13" "" "bst artifact push Manual"
+.TH "BST ARTIFACT PUSH" "1" "2020-10-07" "" "bst artifact push Manual"
 .SH NAME
 bst\-artifact\-push \- Push a built artifact
 .SH SYNOPSIS

--- a/man/bst-artifact-server.1
+++ b/man/bst-artifact-server.1
@@ -1,4 +1,4 @@
-.TH "BST-ARTIFACT-SERVER" "1" "2020-08-13" "" "bst-artifact-server Manual"
+.TH "BST-ARTIFACT-SERVER" "1" "2020-10-07" "" "bst-artifact-server Manual"
 .SH NAME
 bst-artifact-server \- CAS Artifact Server
 .SH SYNOPSIS

--- a/man/bst-artifact-show.1
+++ b/man/bst-artifact-show.1
@@ -1,4 +1,4 @@
-.TH "BST ARTIFACT SHOW" "1" "2020-08-13" "" "bst artifact show Manual"
+.TH "BST ARTIFACT SHOW" "1" "2020-10-07" "" "bst artifact show Manual"
 .SH NAME
 bst\-artifact\-show \- Show the cached state of artifacts
 .SH SYNOPSIS

--- a/man/bst-artifact.1
+++ b/man/bst-artifact.1
@@ -1,4 +1,4 @@
-.TH "BST ARTIFACT" "1" "2020-08-13" "" "bst artifact Manual"
+.TH "BST ARTIFACT" "1" "2020-10-07" "" "bst artifact Manual"
 .SH NAME
 bst\-artifact \- Manipulate cached artifacts.
 .SH SYNOPSIS

--- a/man/bst-build.1
+++ b/man/bst-build.1
@@ -1,4 +1,4 @@
-.TH "BST BUILD" "1" "2020-08-13" "" "bst build Manual"
+.TH "BST BUILD" "1" "2020-10-07" "" "bst build Manual"
 .SH NAME
 bst\-build \- Build elements in a pipeline
 .SH SYNOPSIS

--- a/man/bst-help.1
+++ b/man/bst-help.1
@@ -1,4 +1,4 @@
-.TH "BST HELP" "1" "2020-08-13" "" "bst help Manual"
+.TH "BST HELP" "1" "2020-10-07" "" "bst help Manual"
 .SH NAME
 bst\-help \- Print usage information
 .SH SYNOPSIS

--- a/man/bst-init.1
+++ b/man/bst-init.1
@@ -1,4 +1,4 @@
-.TH "BST INIT" "1" "2020-08-13" "" "bst init Manual"
+.TH "BST INIT" "1" "2020-10-07" "" "bst init Manual"
 .SH NAME
 bst\-init \- Initialize a new BuildStream project
 .SH SYNOPSIS

--- a/man/bst-shell.1
+++ b/man/bst-shell.1
@@ -1,4 +1,4 @@
-.TH "BST SHELL" "1" "2020-08-13" "" "bst shell Manual"
+.TH "BST SHELL" "1" "2020-10-07" "" "bst shell Manual"
 .SH NAME
 bst\-shell \- Shell into an element's sandbox environment
 .SH SYNOPSIS
@@ -36,8 +36,8 @@ Mount a file or directory into the sandbox
 \fB\-\-isolate\fP
 Create an isolated build sandbox
 .TP
-\fB\-t,\fP \-\-use\-buildtree [ask|try|always|never]
-Stage a buildtree. If `always` is set, will always fail to build if a buildtree is not available. --pull and pull-buildtrees configuration is needed if trying to query for remotely cached buildtrees.  [default: ask]
+\fB\-t,\fP \-\-use\-buildtree [try|always|never]
+Stage a buildtree. If `always` is set, will always fail to build if a buildtree is not available. --pull and pull-buildtrees configuration is needed if trying to query for remotely cached buildtrees.  [default: never]
 .TP
 \fB\-\-pull\fP
 Attempt to pull missing or incomplete artifacts

--- a/man/bst-show.1
+++ b/man/bst-show.1
@@ -1,4 +1,4 @@
-.TH "BST SHOW" "1" "2020-08-13" "" "bst show Manual"
+.TH "BST SHOW" "1" "2020-10-07" "" "bst show Manual"
 .SH NAME
 bst\-show \- Show elements in the pipeline
 .SH SYNOPSIS

--- a/man/bst-source-checkout.1
+++ b/man/bst-source-checkout.1
@@ -1,4 +1,4 @@
-.TH "BST SOURCE CHECKOUT" "1" "2020-08-13" "" "bst source checkout Manual"
+.TH "BST SOURCE CHECKOUT" "1" "2020-10-07" "" "bst source checkout Manual"
 .SH NAME
 bst\-source\-checkout \- Checkout sources of an element
 .SH SYNOPSIS

--- a/man/bst-source-fetch.1
+++ b/man/bst-source-fetch.1
@@ -1,4 +1,4 @@
-.TH "BST SOURCE FETCH" "1" "2020-08-13" "" "bst source fetch Manual"
+.TH "BST SOURCE FETCH" "1" "2020-10-07" "" "bst source fetch Manual"
 .SH NAME
 bst\-source\-fetch \- Fetch sources in a pipeline
 .SH SYNOPSIS

--- a/man/bst-source-push.1
+++ b/man/bst-source-push.1
@@ -1,4 +1,4 @@
-.TH "BST SOURCE PUSH" "1" "2020-08-13" "" "bst source push Manual"
+.TH "BST SOURCE PUSH" "1" "2020-10-07" "" "bst source push Manual"
 .SH NAME
 bst\-source\-push \- Push sources in a pipeline
 .SH SYNOPSIS

--- a/man/bst-source-track.1
+++ b/man/bst-source-track.1
@@ -1,4 +1,4 @@
-.TH "BST SOURCE TRACK" "1" "2020-08-13" "" "bst source track Manual"
+.TH "BST SOURCE TRACK" "1" "2020-10-07" "" "bst source track Manual"
 .SH NAME
 bst\-source\-track \- Track new source references
 .SH SYNOPSIS

--- a/man/bst-source.1
+++ b/man/bst-source.1
@@ -1,4 +1,4 @@
-.TH "BST SOURCE" "1" "2020-08-13" "" "bst source Manual"
+.TH "BST SOURCE" "1" "2020-10-07" "" "bst source Manual"
 .SH NAME
 bst\-source \- Manipulate sources for an element
 .SH SYNOPSIS

--- a/man/bst-workspace-close.1
+++ b/man/bst-workspace-close.1
@@ -1,4 +1,4 @@
-.TH "BST WORKSPACE CLOSE" "1" "2020-08-13" "" "bst workspace close Manual"
+.TH "BST WORKSPACE CLOSE" "1" "2020-10-07" "" "bst workspace close Manual"
 .SH NAME
 bst\-workspace\-close \- Close workspaces
 .SH SYNOPSIS

--- a/man/bst-workspace-list.1
+++ b/man/bst-workspace-list.1
@@ -1,4 +1,4 @@
-.TH "BST WORKSPACE LIST" "1" "2020-08-13" "" "bst workspace list Manual"
+.TH "BST WORKSPACE LIST" "1" "2020-10-07" "" "bst workspace list Manual"
 .SH NAME
 bst\-workspace\-list \- List open workspaces
 .SH SYNOPSIS

--- a/man/bst-workspace-open.1
+++ b/man/bst-workspace-open.1
@@ -1,4 +1,4 @@
-.TH "BST WORKSPACE OPEN" "1" "2020-08-13" "" "bst workspace open Manual"
+.TH "BST WORKSPACE OPEN" "1" "2020-10-07" "" "bst workspace open Manual"
 .SH NAME
 bst\-workspace\-open \- Open a new workspace
 .SH SYNOPSIS

--- a/man/bst-workspace-reset.1
+++ b/man/bst-workspace-reset.1
@@ -1,4 +1,4 @@
-.TH "BST WORKSPACE RESET" "1" "2020-08-13" "" "bst workspace reset Manual"
+.TH "BST WORKSPACE RESET" "1" "2020-10-07" "" "bst workspace reset Manual"
 .SH NAME
 bst\-workspace\-reset \- Reset a workspace to its original state
 .SH SYNOPSIS

--- a/man/bst-workspace.1
+++ b/man/bst-workspace.1
@@ -1,4 +1,4 @@
-.TH "BST WORKSPACE" "1" "2020-08-13" "" "bst workspace Manual"
+.TH "BST WORKSPACE" "1" "2020-10-07" "" "bst workspace Manual"
 .SH NAME
 bst\-workspace \- Manipulate developer workspaces
 .SH SYNOPSIS

--- a/man/bst.1
+++ b/man/bst.1
@@ -1,4 +1,4 @@
-.TH "BST" "1" "2020-08-13" "" "bst Manual"
+.TH "BST" "1" "2020-10-07" "" "bst Manual"
 .SH NAME
 bst \- Build and manipulate BuildStream projects...
 .SH SYNOPSIS

--- a/src/buildstream/_frontend/app.py
+++ b/src/buildstream/_frontend/app.py
@@ -446,15 +446,16 @@ class App:
     # if they are available in the execution context.
     #
     # Args:
-    #    element_name (str): The element's full name
-    #    element_key (tuple): The element's display key
+    #    element (Element): The element
     #
     # Returns:
     #    (str): The formatted prompt to display in the shell
     #
-    def shell_prompt(self, element_name, element_key):
+    def shell_prompt(self, element):
 
-        _, key, dim = element_key
+        element_name = element._get_full_name()
+
+        _, key, dim = element._get_display_key()
 
         if self.colors:
             prompt = (
@@ -703,10 +704,14 @@ class App:
                 if choice == "shell":
                     click.echo("\nDropping into an interactive shell in the failed build sandbox\n", err=True)
                     try:
-                        unique_id, element_key = element
-                        prompt = self.shell_prompt(full_name, element_key)
+                        unique_id, _ = element
                         self.stream.shell(
-                            None, _Scope.BUILD, prompt, isolate=True, usebuildtree="always", unique_id=unique_id
+                            None,
+                            _Scope.BUILD,
+                            self.shell_prompt,
+                            isolate=True,
+                            usebuildtree="always",
+                            unique_id=unique_id,
                         )
                     except BstError as e:
                         click.echo("Error while attempting to create interactive shell: {}".format(e), err=True)

--- a/src/buildstream/_frontend/cli.py
+++ b/src/buildstream/_frontend/cli.py
@@ -617,6 +617,10 @@ def shell(app, element, mount, isolate, build_, cli_buildtree, pull_, command):
     from ..element import _Scope
     from .._project import HostMount
 
+    # Buildtree can only be used with build shells
+    if cli_buildtree != "never":
+        build_ = True
+
     scope = _Scope.BUILD if build_ else _Scope.RUN
 
     # We may need to fetch dependency artifacts if we're pulling the artifact

--- a/src/buildstream/_frontend/cli.py
+++ b/src/buildstream/_frontend/cli.py
@@ -640,10 +640,6 @@ def shell(app, element, mount, isolate, build_, cli_buildtree, pull_, command):
         element = elements[-1]
         pull_dependencies = elements[:-1] if pull_ else None
 
-        element_name = element._get_full_name()
-        element_key = element._get_display_key()
-
-        prompt = app.shell_prompt(element_name, element_key)
         mounts = [HostMount(path, host_path) for host_path, path in mount]
 
         artifact_is_cached = element._cached()
@@ -700,7 +696,7 @@ def shell(app, element, mount, isolate, build_, cli_buildtree, pull_, command):
             exitcode = app.stream.shell(
                 element,
                 scope,
-                prompt,
+                app.shell_prompt,
                 mounts=mounts,
                 isolate=isolate,
                 command=command,

--- a/src/buildstream/_frontend/cli.py
+++ b/src/buildstream/_frontend/cli.py
@@ -578,8 +578,8 @@ def show(app, elements, deps, except_, order, format_):
     "--use-buildtree",
     "-t",
     "cli_buildtree",
-    type=click.Choice(["ask", "try", "always", "never"]),
-    default="ask",
+    type=click.Choice(["try", "always", "never"]),
+    default="never",
     show_default=True,
     help=(
         "Stage a buildtree. If `always` is set, will always fail to "
@@ -687,31 +687,6 @@ def shell(app, element, mount, isolate, build_, cli_buildtree, pull_, command):
                         "Artifact not cached locally. Can be retried with --pull and pull-buildtrees configured"
                     )
                 click.echo("WARNING: buildtree is not cached locally, shell will be loaded without it", err=True)
-        else:
-            # If the value has defaulted to ask and in non interactive mode, don't consider the buildtree, this
-            # being the default behaviour of the command
-            if app.interactive and cli_buildtree == "ask":
-                if buildtree_is_cached and bool(click.confirm("Do you want to use the cached buildtree?")):
-                    use_buildtree = "always"
-                elif can_attempt_pull:
-                    # If buildtree not cached, check if it's worth presenting the user a dialogue
-                    message = None
-                    if artifact_is_cached:
-                        if buildtree_exists:
-                            message = "Buildtree not cached but can be pulled if in available remotes, do you want to use it?"
-                    else:
-                        message = "Element is not cached so buildtree status unknown, do you want to pull and use it?"
-                    if message:
-                        try:
-                            choice = click.prompt(
-                                message, type=click.Choice(["try", "always", "never"]), err=True, show_choices=True,
-                            )
-                        except click.Abort:
-                            click.echo("Aborting", err=True)
-                            sys.exit(-1)
-
-                        if choice != "never":
-                            use_buildtree = choice
 
         # Raise warning if the element is cached in a failed state
         if use_buildtree and element._cached_failure():

--- a/src/buildstream/_stream.py
+++ b/src/buildstream/_stream.py
@@ -169,7 +169,7 @@ class Stream:
     # Args:
     #    element (Element): An Element object to run the shell for
     #    scope (_Scope): The scope for the shell (_Scope.BUILD or _Scope.RUN)
-    #    prompt (str): The prompt to display in the shell
+    #    prompt (function): A function to return the prompt to display in the shell
     #    mounts (list of HostMount): Additional directories to mount into the sandbox
     #    isolate (bool): Whether to isolate the environment like we do in builds
     #    command (list): An argv to launch in the sandbox, or None
@@ -243,7 +243,7 @@ class Stream:
             self._pipeline.assert_sources_cached([element])
 
         return element._shell(
-            scope, mounts=mounts, isolate=isolate, prompt=prompt, command=command, usebuildtree=buildtree
+            scope, mounts=mounts, isolate=isolate, prompt=prompt(element), command=command, usebuildtree=buildtree
         )
 
     # build()

--- a/src/buildstream/element.py
+++ b/src/buildstream/element.py
@@ -1557,10 +1557,13 @@ class Element(Plugin):
 
     # _set_required():
     #
-    # Mark this element and its runtime dependencies as required.
+    # Mark this element and its dependencies as required.
     # This unblocks pull/fetch/build.
     #
-    def _set_required(self):
+    # Args:
+    #    scope (_Scope): The scope of dependencies to mark as required
+    #
+    def _set_required(self, scope=_Scope.RUN):
         assert utils._is_main_process(), "This has an impact on all elements and must be run in the main process"
 
         if self.__required:
@@ -1569,9 +1572,9 @@ class Element(Plugin):
 
         self.__required = True
 
-        # Request artifacts of runtime dependencies
-        for dep in self._dependencies(_Scope.RUN, recurse=False):
-            dep._set_required()
+        # Request artifacts of dependencies
+        for dep in self._dependencies(scope, recurse=False):
+            dep._set_required(scope=_Scope.RUN)
 
         # When an element becomes required, it must be assembled for
         # the current pipeline. `__schedule_assembly_when_necessary()`

--- a/tests/integration/shellbuildtrees.py
+++ b/tests/integration/shellbuildtrees.py
@@ -131,7 +131,7 @@ def test_buildtree_from_failure(cli_integration, datafiles):
         project=project, args=["shell", "--build", element_name, "--use-buildtree", "always", "--", "cat", "test"]
     )
     res.assert_success()
-    assert "WARNING: using a buildtree from a failed build" in res.stderr
+    assert "WARNING using a buildtree from a failed build" in res.stderr
     assert "Hi" in res.output
 
 
@@ -175,7 +175,7 @@ def test_buildtree_from_failure_option_always(cli_integration, tmpdir, datafiles
         project=project, args=["shell", "--build", element_name, "--use-buildtree", "always", "--", "cat", "test"]
     )
     res.assert_success()
-    assert "WARNING: using a buildtree from a failed build" in res.stderr
+    assert "WARNING using a buildtree from a failed build" in res.stderr
     assert "Hi" in res.output
 
 
@@ -257,7 +257,7 @@ def test_buildtree_options(cli, tmpdir, datafiles):
         )
         assert "Hi" not in res.output
         assert "Attempting to fetch missing artifact buildtrees" not in res.stderr
-        assert "WARNING: buildtree is not cached locally, shell will be loaded without it" in res.stderr
+        assert "WARNING buildtree is not cached locally, shell will be loaded without it" in res.stderr
 
         # Check correctly handling the lack of buildtree, with 'try' attempting and succeeding
         # to pull the buildtree as the user context allow the pulling of buildtrees and it is

--- a/tests/integration/shellbuildtrees.py
+++ b/tests/integration/shellbuildtrees.py
@@ -70,14 +70,14 @@ def test_buildtree_staged_warn_empty_cached(cli_integration, tmpdir, datafiles):
         project=project, args=["shell", "--build", "--use-buildtree", "always", element_name, "--", "cat", "test"]
     )
     res.assert_main_error(ErrorDomain.APP, None)
-    assert "Artifact was created without buildtree, unable to launch shell with it" in res.stderr
+    assert "Error launching shell: Artifact was created without buildtree" in res.stderr
 
     # Now attempt the same with the try option, this should not attempt to find a buildtree
     # and just launch the shell, however the cat should still fail.
     res = cli_integration.run(
         project=project, args=["shell", "--build", "--use-buildtree", "try", element_name, "--", "cat", "test"]
     )
-    assert "Artifact created without buildtree, shell will be loaded without it" in res.stderr
+    assert "Artifact was created without buildtree, shell will be loaded without it" in res.stderr
     assert "Hi" not in res.output
 
 
@@ -153,7 +153,7 @@ def test_buildtree_from_failure_option_never(cli_integration, tmpdir, datafiles)
         project=project, args=["shell", "--build", element_name, "--use-buildtree", "always", "--", "cat", "test"]
     )
     res.assert_main_error(ErrorDomain.APP, None)
-    assert "Artifact was created without buildtree, unable to launch shell with it" in res.stderr
+    assert "Error launching shell: Artifact was created without buildtree" in res.stderr
 
 
 @pytest.mark.datafiles(DATA_DIR)
@@ -257,7 +257,7 @@ def test_buildtree_options(cli, tmpdir, datafiles):
         )
         assert "Hi" not in res.output
         assert "Attempting to fetch missing artifact buildtrees" not in res.stderr
-        assert "WARNING buildtree is not cached locally, shell will be loaded without it" in res.stderr
+        assert "WARNING Buildtree is not cached locally" in res.stderr
 
         # Check correctly handling the lack of buildtree, with 'try' attempting and succeeding
         # to pull the buildtree as the user context allow the pulling of buildtrees and it is
@@ -277,7 +277,6 @@ def test_buildtree_options(cli, tmpdir, datafiles):
                 "test",
             ],
         )
-        assert "Attempting to fetch missing artifact buildtree" in res.stderr
         assert "Hi" in res.output
         shutil.rmtree(os.path.join(os.path.join(str(tmpdir), "cache", "cas")))
         shutil.rmtree(os.path.join(os.path.join(str(tmpdir), "cache", "artifacts")))
@@ -291,12 +290,8 @@ def test_buildtree_options(cli, tmpdir, datafiles):
             project=project, args=["shell", "--build", element_name, "--use-buildtree", "always", "--", "cat", "test"]
         )
         res.assert_main_error(ErrorDomain.APP, None)
-        assert (
-            "Artifact has a buildtree but it isn't cached. Can be retried with --pull and pull-buildtrees configured"
-            in res.stderr
-        )
+        assert "Buildtree is not cached locally" in res.stderr
         assert "Hi" not in res.output
-        assert "Attempting to fetch missing artifact buildtree" not in res.stderr
 
         # Check that when user context is set to pull buildtrees and a remote has the buildtree,
         # 'always' will attempt and succeed at pulling the missing buildtree with --pull set.
@@ -316,10 +311,7 @@ def test_buildtree_options(cli, tmpdir, datafiles):
             ],
         )
         assert "Hi" in res.output
-        assert (
-            "buildtree is not cached locally but did exist, will attempt to pull from available remotes" in res.stderr
-        )
-        assert "Attempting to fetch missing artifact buildtree" in res.stderr
+        assert res.get_pulled_elements() == [element_name]
 
 
 # Tests running pull and pull-buildtree options at the same time.
@@ -348,7 +340,7 @@ def test_pull_buildtree_pulled(cli, tmpdir, datafiles):
             args=["shell", "--build", element_name, "--pull", "--use-buildtree", "always", "--", "cat", "test",],
         )
         res.assert_main_error(ErrorDomain.APP, None)
-        assert "Artifact not cached locally. Can be retried with --pull and pull-buildtrees configured" in res.stderr
+        assert "Buildtree is not cached locally" in res.stderr
 
         # Check it's using the cached build tree, because --pull
         # and pull-buildtrees were both set


### PR DESCRIPTION
[See original merge request on GitLab](https://gitlab.com/BuildStream/buildstream/-/merge_requests/2084)
In GitLab by [[Gitlab user @juergbi]](https://gitlab.com/juergbi) on Oct 7, 2020, 13:55

* Drop support for `bst shell --use-buildtree=ask`: [Proposal on ML](https://lists.apache.org/thread.html/r37bf22258e422f44a654a590a748d336dff60f8f4d5ca8bbe57f2950%40%3Cdev.buildstream.apache.org%3E)
* Make `bst shell --use-buildtree` imply `--build`
* Use single scheduler run for pulling dependencies and buildtree
* Deduplicate cache checks and corresponding warning/error messages with and without pulling enabled

This is in preparation of support for remote execution without downloading blobs.