### PR TITLE
Simplify source workspace tests

### DIFF
--- a/src/buildstream/testing/_sourcetests/workspace.py
+++ b/src/buildstream/testing/_sourcetests/workspace.py
@@ -59,11 +59,7 @@ def test_open(cli, tmpdir, datafiles, kind):
 
     # Now open the workspace, this should have the effect of automatically
     # fetching the source from the repo.
-    args = ["workspace", "open"]
-    args.extend(["--directory", workspace_dir])
-
-    args.append(element_name)
-    result = cli.run(cwd=workspace_cmd, project=project_path, args=args)
+    result = cli.run(project=project_path, args=["workspace", "open", "--directory", workspace_dir, element_name])
 
     result.assert_success()
 

--- a/src/buildstream/testing/_sourcetests/workspace.py
+++ b/src/buildstream/testing/_sourcetests/workspace.py
@@ -32,59 +32,44 @@ TOP_DIR = os.path.dirname(os.path.realpath(__file__))
 DATA_DIR = os.path.join(TOP_DIR, "project")
 
 
-class WorkspaceCreator:
-    def __init__(self, cli, tmpdir, datafiles):
-        self.cli = cli
-        self.tmpdir = tmpdir
-
-        self.project_path = str(datafiles)
-        self.bin_files_path = os.path.join(self.project_path, "files", "bin-files")
-
-        self.workspace_cmd = os.path.join(self.project_path, "workspace_cmd")
-
-    def create_workspace_element(self, kind):
-        element_name = "workspace-test-{}.bst".format(kind)
-        element_path = os.path.join(self.project_path, "elements")
-        # remove the '.bst' at the end of the element
-        workspace_dir = os.path.join(self.workspace_cmd, element_name[-4:])
-
-        # Create our repo object of the given source type with
-        # the bin files, and then collect the initial ref.
-        repo = create_repo(kind, str(self.tmpdir))
-        ref = repo.create(self.bin_files_path)
-
-        # Write out our test target
-        element = {"kind": "import", "sources": [repo.source_config(ref=ref)]}
-        _yaml.roundtrip_dump(element, os.path.join(element_path, element_name))
-
-        # Assert that there is no reference, a fetch is needed
-        assert self.cli.get_element_state(self.project_path, element_name) == "fetch needed"
-        return element_name, workspace_dir
-
-    def open_workspace(self, kind):
-
-        element_name, workspace_dir = self.create_workspace_element(kind)
-        os.makedirs(self.workspace_cmd, exist_ok=True)
-
-        # Now open the workspace, this should have the effect of automatically
-        # fetching the source from the repo.
-        args = ["workspace", "open"]
-        args.extend(["--directory", workspace_dir])
-
-        args.append(element_name)
-        result = self.cli.run(cwd=self.workspace_cmd, project=self.project_path, args=args)
-
-        result.assert_success()
-
-        # Assert that we are now buildable because the source is now cached.
-        assert self.cli.get_element_state(self.project_path, element_name) == "buildable"
-
-        # Check that the executable hello file is found in each workspace
-        filename = os.path.join(workspace_dir, "usr", "bin", "hello")
-        assert os.path.exists(filename)
-
-
 @pytest.mark.datafiles(DATA_DIR)
 def test_open(cli, tmpdir, datafiles, kind):
-    workspace_object = WorkspaceCreator(cli, tmpdir, datafiles)
-    workspace_object.open_workspace(kind)
+    project_path = str(datafiles)
+    bin_files_path = os.path.join(project_path, "files", "bin-files")
+
+    element_name = "workspace-test-{}.bst".format(kind)
+    element_path = os.path.join(project_path, "elements")
+
+    # Create our repo object of the given source type with
+    # the bin files, and then collect the initial ref.
+    repo = create_repo(kind, str(tmpdir))
+    ref = repo.create(bin_files_path)
+
+    # Write out our test target
+    element = {"kind": "import", "sources": [repo.source_config(ref=ref)]}
+    _yaml.roundtrip_dump(element, os.path.join(element_path, element_name))
+
+    # Assert that there is no reference, a fetch is needed
+    assert cli.get_element_state(project_path, element_name) == "fetch needed"
+
+    workspace_cmd = os.path.join(project_path, "workspace_cmd")
+    os.makedirs(workspace_cmd, exist_ok=True)
+    # remove the '.bst' at the end of the element
+    workspace_dir = os.path.join(workspace_cmd, element_name[-4:])
+
+    # Now open the workspace, this should have the effect of automatically
+    # fetching the source from the repo.
+    args = ["workspace", "open"]
+    args.extend(["--directory", workspace_dir])
+
+    args.append(element_name)
+    result = cli.run(cwd=workspace_cmd, project=project_path, args=args)
+
+    result.assert_success()
+
+    # Assert that we are now buildable because the source is now cached.
+    assert cli.get_element_state(project_path, element_name) == "buildable"
+
+    # Check that the executable hello file is found in each workspace
+    filename = os.path.join(workspace_dir, "usr", "bin", "hello")
+    assert os.path.exists(filename)

--- a/src/buildstream/testing/_sourcetests/workspace.py
+++ b/src/buildstream/testing/_sourcetests/workspace.py
@@ -33,7 +33,7 @@ DATA_DIR = os.path.join(TOP_DIR, "project")
 
 
 @pytest.mark.datafiles(DATA_DIR)
-def test_open(cli, tmpdir, datafiles, kind):
+def test_open(cli, tmpdir_factory, datafiles, kind):
     project_path = str(datafiles)
     bin_files_path = os.path.join(project_path, "files", "bin-files")
 
@@ -42,7 +42,7 @@ def test_open(cli, tmpdir, datafiles, kind):
 
     # Create our repo object of the given source type with
     # the bin files, and then collect the initial ref.
-    repo = create_repo(kind, str(tmpdir))
+    repo = create_repo(kind, str(tmpdir_factory.mktemp("repo-{}".format(kind))))
     ref = repo.create(bin_files_path)
 
     # Write out our test target
@@ -52,10 +52,7 @@ def test_open(cli, tmpdir, datafiles, kind):
     # Assert that there is no reference, a fetch is needed
     assert cli.get_element_state(project_path, element_name) == "fetch needed"
 
-    workspace_cmd = os.path.join(project_path, "workspace_cmd")
-    os.makedirs(workspace_cmd, exist_ok=True)
-    # remove the '.bst' at the end of the element
-    workspace_dir = os.path.join(workspace_cmd, element_name[-4:])
+    workspace_dir = os.path.join(tmpdir_factory.mktemp("opened_workspace"))
 
     # Now open the workspace, this should have the effect of automatically
     # fetching the source from the repo.


### PR DESCRIPTION
[See original merge request on GitLab](https://gitlab.com/BuildStream/buildstream/-/merge_requests/2085)
In GitLab by [[Gitlab user @BenjaminSchubert]](https://gitlab.com/BenjaminSchubert) on Oct 9, 2020, 12:46

## Description

[//]: # (Provide a description of the MR including what it resolves)

This simplifies the source workspace tests, by removing a lot of the complexity that got brought in by copying the workspace element tests