### PR TITLE
WIP: bst fmt: Add basic functionality

### DIFF
--- a/buildstream/_frontend/cli.py
+++ b/buildstream/_frontend/cli.py
@@ -354,6 +354,7 @@ def build(app, elements, all_, track_, track_save, track_all, track_except, trac
                          track_cross_junctions=track_cross_junctions,
                          build_all=all_)
 
+
 ##################################################################
 #                         Format Command                         #
 ##################################################################

--- a/buildstream/_frontend/cli.py
+++ b/buildstream/_frontend/cli.py
@@ -354,6 +354,29 @@ def build(app, elements, all_, track_, track_save, track_all, track_except, trac
                          track_cross_junctions=track_cross_junctions,
                          build_all=all_)
 
+##################################################################
+#                         Format Command                         #
+##################################################################
+@cli.command(short_help="Format element files")
+@click.option('--all', 'all_', default=False, is_flag=True,
+              help="Format all dependencies of the targets")
+@click.option('--except', 'except_', multiple=True,
+              type=click.Path(readable=False),
+              help="Except certain files from formatting (has no effect without `--all`)")
+@click.argument('elements', nargs=-1,
+                type=click.Path(readable=False))
+@click.pass_obj
+def fmt(app, elements, all_, except_):
+    """Formats element files into a consistent style. This style is the one
+    defaulted to by ruamel.yaml, so is the recommended format for a
+    BuildStream project.
+
+    By default this will format just the specified element, but you can format
+    all the elements at once by passing the `--all` flag.
+    """
+    with app.initialized(session_name="Format"):
+        app.stream.format(elements, except_targets=except_, format_all=all_)
+
 
 ##################################################################
 #                           Pull Command                         #

--- a/buildstream/_scheduler/__init__.py
+++ b/buildstream/_scheduler/__init__.py
@@ -24,6 +24,7 @@ from .queues.trackqueue import TrackQueue
 from .queues.buildqueue import BuildQueue
 from .queues.pushqueue import PushQueue
 from .queues.pullqueue import PullQueue
+from .queues.formatqueue import FormatQueue
 
 from .scheduler import Scheduler, SchedStatus
 from .jobs import ElementJob

--- a/buildstream/_scheduler/queues/formatqueue.py
+++ b/buildstream/_scheduler/queues/formatqueue.py
@@ -1,0 +1,13 @@
+# Local imports
+from . import Queue
+from ..resources import ResourceType
+
+
+class FormatQueue(Queue):
+
+    action_name = "Format"
+    complete_name = "Formatted"
+    resources = [ResourceType.PROCESS]
+
+    def process(self, element):
+        element._format()

--- a/buildstream/buildelement.py
+++ b/buildstream/buildelement.py
@@ -172,6 +172,7 @@ class BuildElement(Element):
         for command_name in _legacy_command_steps:
             if command_name in _command_steps:
                 self.__commands[command_name] = self.__get_commands(node, command_name)
+                self.keyorder.append(command_name)
             else:
                 self.__commands[command_name] = []
 

--- a/buildstream/element.py
+++ b/buildstream/element.py
@@ -1332,6 +1332,14 @@ class Element(Plugin):
 
         return refs
 
+    # _format()
+    #
+    # Dumps an element's yaml file in canonical format
+    #
+    def _format(self):
+        provenance = self._get_provenance()
+        _yaml.dump(provenance.toplevel, provenance.filename.name)
+
     # _prepare_sandbox():
     #
     # This stages things for either _shell() (below) or also

--- a/buildstream/element.py
+++ b/buildstream/element.py
@@ -269,6 +269,9 @@ class Element(Plugin):
                 # This will taint the artifact, disable pushing.
                 self.__sandbox_config_supported = False
 
+        self.keyorder = ['kind', 'description', 'depends', 'variables',
+                         'environment', 'config', 'public', 'sandbox', 'sources']
+
     def __lt__(self, other):
         return self.name < other.name
 
@@ -1338,7 +1341,17 @@ class Element(Plugin):
     #
     def _format(self):
         provenance = self._get_provenance()
-        _yaml.dump(provenance.toplevel, provenance.filename.name)
+
+        _yaml.BstFormatter.keyorder = self.keyorder
+
+        # We need to add the key orders for each source into the
+        # global keyorder, as sources are dumped with the element.
+        for s in self.sources():
+            for key in s.keyorder:
+                if key not in _yaml.BstFormatter.keyorder:
+                    _yaml.BstFormatter.keyorder += s.keyorder
+
+        _yaml.dump(provenance.toplevel, provenance.filename.name, dumper=_yaml.BstFormatter)
 
     # _prepare_sandbox():
     #

--- a/buildstream/plugin.py
+++ b/buildstream/plugin.py
@@ -188,6 +188,8 @@ class Plugin():
         self.__kind = modulename.split('.')[-1]
         self.debug("Created: {}".format(self))
 
+        self.keyorder = []
+
     def __del__(self):
         # Dont send anything through the Message() pipeline at destruction time,
         # any subsequent lookup of plugin by unique id would raise KeyError.

--- a/buildstream/plugins/elements/compose.py
+++ b/buildstream/plugins/elements/compose.py
@@ -70,6 +70,8 @@ class ComposeElement(Element):
         self.exclude = self.node_get_member(node, list, 'exclude')
         self.include_orphans = self.node_get_member(node, bool, 'include-orphans')
 
+        self.keyorder += ['integrate', 'include', 'exclude', 'include-orphans']
+
     def preflight(self):
         pass
 

--- a/buildstream/plugins/elements/filter.py
+++ b/buildstream/plugins/elements/filter.py
@@ -65,6 +65,8 @@ class FilterElement(Element):
         self.exclude = self.node_get_member(node, list, 'exclude')
         self.include_orphans = self.node_get_member(node, bool, 'include-orphans')
 
+        self.keyorder += ['include', 'exclude', 'include-orphans']
+
     def preflight(self):
         # Exactly one build-depend is permitted
         build_deps = list(self.dependencies(Scope.BUILD, recurse=False))

--- a/buildstream/plugins/elements/junction.py
+++ b/buildstream/plugins/elements/junction.py
@@ -140,6 +140,7 @@ class JunctionElement(Element):
     def configure(self, node):
         self.path = self.node_get_member(node, str, 'path', default='')
         self.options = self.node_get_member(node, Mapping, 'options', default={})
+        self.keyorder += ['path', 'options']
 
     def preflight(self):
         pass

--- a/buildstream/plugins/elements/script.py
+++ b/buildstream/plugins/elements/script.py
@@ -51,6 +51,7 @@ class ScriptElement(buildstream.ScriptElement):
         self.node_validate(node, [
             'commands', 'root-read-only', 'layout'
         ])
+        self.keyorder += ['layout', 'root-read-only', 'commands']
 
         cmds = self.node_subst_list(node, "commands")
         self.add_commands("commands", cmds)

--- a/buildstream/plugins/sources/_downloadablefilesource.py
+++ b/buildstream/plugins/sources/_downloadablefilesource.py
@@ -82,6 +82,8 @@ class DownloadableFileSource(Source):
         self.url = self.translate_url(self.original_url)
         self._warn_deprecated_etag(node)
 
+        self.keyorder += ['url', 'ref', 'etag']
+
     def preflight(self):
         return
 

--- a/buildstream/plugins/sources/bzr.py
+++ b/buildstream/plugins/sources/bzr.py
@@ -68,6 +68,8 @@ class BzrSource(Source):
     def configure(self, node):
         self.node_validate(node, ['url', 'track', 'ref'] + Source.COMMON_CONFIG_KEYS)
 
+        self.keyorder += ['url', 'track', 'ref']
+
         self.original_url = self.node_get_member(node, str, 'url')
         self.tracking = self.node_get_member(node, str, 'track')
         self.ref = self.node_get_member(node, str, 'ref', None)

--- a/buildstream/plugins/sources/git.py
+++ b/buildstream/plugins/sources/git.py
@@ -506,6 +506,8 @@ class GitSource(Source):
                        'track-tags', 'tags']
         self.node_validate(node, config_keys + Source.COMMON_CONFIG_KEYS)
 
+        self.keyorder += config_keys
+
         tags_node = self.node_get_member(node, list, 'tags', [])
         for tag_node in tags_node:
             self.node_validate(tag_node, ['tag', 'commit', 'annotated'])

--- a/buildstream/plugins/sources/local.py
+++ b/buildstream/plugins/sources/local.py
@@ -53,6 +53,7 @@ class LocalSource(Source):
 
     def configure(self, node):
         self.node_validate(node, ['path'] + Source.COMMON_CONFIG_KEYS)
+        self.keyorder += ['path']
         self.path = self.node_get_project_path(node, 'path')
         self.fullpath = os.path.join(self.get_project_directory(), self.path)
 

--- a/buildstream/plugins/sources/ostree.py
+++ b/buildstream/plugins/sources/ostree.py
@@ -65,6 +65,7 @@ class OSTreeSource(Source):
     def configure(self, node):
 
         self.node_validate(node, ['url', 'ref', 'track', 'gpg-key'] + Source.COMMON_CONFIG_KEYS)
+        self.keyorder += ['url', 'track', 'ref', 'gpg-key']
 
         self.original_url = self.node_get_member(node, str, 'url')
         self.url = self.translate_url(self.original_url)

--- a/buildstream/plugins/sources/patch.py
+++ b/buildstream/plugins/sources/patch.py
@@ -53,6 +53,7 @@ class PatchSource(Source):
     # pylint: disable=attribute-defined-outside-init
 
     def configure(self, node):
+        self.keyorder += ['strip-level', 'path']
         self.path = self.node_get_project_path(node, 'path',
                                                check_is_file=True)
         self.strip_level = self.node_get_member(node, int, "strip-level", 1)

--- a/buildstream/plugins/sources/pip.py
+++ b/buildstream/plugins/sources/pip.py
@@ -111,6 +111,7 @@ class PipSource(Source):
     def configure(self, node):
         self.node_validate(node, ['url', 'packages', 'ref', 'requirements-files'] +
                            Source.COMMON_CONFIG_KEYS)
+        self.keyorder += ['url', 'packages', 'ref', 'requirements-files']
         self.ref = self.node_get_member(node, str, 'ref', None)
         self.original_url = self.node_get_member(node, str, 'url', _PYPI_INDEX_URL)
         self.index_url = self.translate_url(self.original_url)

--- a/buildstream/plugins/sources/remote.py
+++ b/buildstream/plugins/sources/remote.py
@@ -61,6 +61,7 @@ class RemoteSource(DownloadableFileSource):
 
     def configure(self, node):
         super().configure(node)
+        self.keyorder += ['filename']
 
         self.filename = self.node_get_member(node, str, 'filename', os.path.basename(self.url))
         self.executable = self.node_get_member(node, bool, 'executable', False)

--- a/buildstream/plugins/sources/tar.py
+++ b/buildstream/plugins/sources/tar.py
@@ -75,6 +75,7 @@ class TarSource(DownloadableFileSource):
         self.base_dir = self.node_get_member(node, str, 'base-dir', '*') or None
 
         self.node_validate(node, DownloadableFileSource.COMMON_CONFIG_KEYS + ['base-dir'])
+        self.keyorder += ['base-dir']
 
     def preflight(self):
         self.host_lzip = None

--- a/buildstream/plugins/sources/zip.py
+++ b/buildstream/plugins/sources/zip.py
@@ -75,6 +75,7 @@ class ZipSource(DownloadableFileSource):
         self.base_dir = self.node_get_member(node, str, 'base-dir', '*') or None
 
         self.node_validate(node, DownloadableFileSource.COMMON_CONFIG_KEYS + ['base-dir'])
+        self.keyorder += ['base-dir']
 
     def get_unique_key(self):
         return super().get_unique_key() + [self.base_dir]

--- a/buildstream/source.py
+++ b/buildstream/source.py
@@ -302,6 +302,8 @@ class Source(Plugin):
         # FIXME: Reconstruct a MetaSource from a Source instead of storing it.
         self.__meta = meta                              # MetaSource stored so we can copy this source later.
 
+        self.keyorder = ['directory'] + self.keyorder
+
         # Collect the composited element configuration and
         # ask the element to configure itself.
         self.__init_defaults(meta)

--- a/tests/completions/completions.py
+++ b/tests/completions/completions.py
@@ -9,6 +9,7 @@ MAIN_COMMANDS = [
     'artifact ',
     'build ',
     'checkout ',
+    'fmt ',
     'help ',
     'init ',
     'pull ',

--- a/tests/integration/fmt.py
+++ b/tests/integration/fmt.py
@@ -1,0 +1,75 @@
+import os
+import pytest
+
+from tests.testutils import cli_integration as cli
+from tests.testutils.site import IS_LINUX
+
+
+DATA_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "project"
+)
+
+
+@pytest.mark.integration
+@pytest.mark.datafiles(DATA_DIR)
+def test_fmt_single(cli, tmpdir, datafiles):
+    project = os.path.join(datafiles.dirname, datafiles.basename)
+    element_name = 'fmt/bad-format.bst'
+    good_element = 'fmt/good-format.bst'
+
+    with open(os.path.join(project, 'elements', good_element)) as element:
+        good = element.readlines()
+
+    res = cli.run(project=project, args=['fmt', element_name])
+    assert res.exit_code == 0
+
+    with open(os.path.join(project, 'elements', element_name)) as element:
+        final = element.readlines()
+
+    # Have to test only the last line, rather than full file because of #767
+    assert final[-1] == good[-1]
+
+
+@pytest.mark.integration
+@pytest.mark.datafiles(DATA_DIR)
+def test_fmt_all(cli, tmpdir, datafiles):
+    project = os.path.join(datafiles.dirname, datafiles.basename)
+    check_elements = ['fmt/bad-format.bst', 'fmt/except.bst']
+    target = 'fmt/stack.bst'
+
+    initial_lines = []
+    for e in check_elements:
+        with open(os.path.join(project, 'elements', e)) as element:
+            initial_lines.append(element.readlines()[-1])
+
+    with open(os.path.join(project, 'elements', 'fmt/good-format.bst')) as element:
+        expected = element.readlines()[-1]
+
+    res = cli.run(project=project, args=['fmt', '--all', target])
+    assert res.exit_code == 0
+
+    for i, _ in enumerate(initial_lines):
+        with open(os.path.join(project, 'elements', check_elements[i])) as element:
+            assert element.readlines()[-1] == expected
+
+
+@pytest.mark.integration
+@pytest.mark.datafiles(DATA_DIR)
+def test_fmt_except(cli, tmpdir, datafiles):
+    project = os.path.join(datafiles.dirname, datafiles.basename)
+    bad_target = 'fmt/bad-format.bst'
+    except_target = 'fmt/except.bst'
+    target = 'fmt/stack.bst'
+
+    with open(os.path.join(project, 'elements', 'fmt/good-format.bst')) as element:
+        formatted = element.readlines()[-1]
+
+    res = cli.run(project=project, args=['fmt', '--all', target, '--except', except_target])
+    assert res.exit_code == 0
+
+    with open(os.path.join(project, 'elements', except_target)) as element:
+        assert formatted != element.readlines()[-1]
+
+    with open(os.path.join(project, 'elements', bad_target)) as element:
+        assert formatted == element.readlines()[-1]

--- a/tests/integration/project/elements/fmt/bad-format.bst
+++ b/tests/integration/project/elements/fmt/bad-format.bst
@@ -1,0 +1,4 @@
+kind: stack
+
+depends:
+  - filename: base.bst

--- a/tests/integration/project/elements/fmt/except.bst
+++ b/tests/integration/project/elements/fmt/except.bst
@@ -1,0 +1,4 @@
+kind: stack
+
+depends:
+  - filename: base.bst

--- a/tests/integration/project/elements/fmt/good-format.bst
+++ b/tests/integration/project/elements/fmt/good-format.bst
@@ -1,0 +1,4 @@
+kind: stack
+
+depends:
+- filename: base.bst

--- a/tests/integration/project/elements/fmt/stack.bst
+++ b/tests/integration/project/elements/fmt/stack.bst
@@ -1,0 +1,5 @@
+kind: stack
+depends:
+- filename: fmt/bad-format.bst
+- filename: fmt/good-format.bst
+- filename: fmt/except.bst


### PR DESCRIPTION
[See original merge request on GitLab](https://gitlab.com/BuildStream/buildstream/-/merge_requests/955)
In GitLab by [[Gitlab user @coldtom]](https://gitlab.com/coldtom) on Nov 15, 2018, 16:55

## Description

Adds a `bst fmt` command, which modifies the format of a projects element files into a canonical yaml format. This has the main benefit of automating files into the format `bst track` will dump them into when run.

Currently the functionality is somewhat stinted by #767, and there are a couple of other features I would like to add to this - namely an option which doesn't modify the yaml, but creates a diff, and a way for a user to define the order of top-level nodes in a `.bst` file, into which `bst fmt` sorts the nodes.

[//]: # (Proposed changes)

Changes proposed in this merge request:
* Add a `bst fmt` command which formats elements into a canonical format

[//]: # (Task or bug number that this MR solves preceded by #)

This merge request,  when approved, will close #485 
