### PR TITLE
_stream.py: Make `_enqueue_plan` a timed activity

### DIFF
--- a/src/buildstream/_scheduler/queues/buildqueue.py
+++ b/src/buildstream/_scheduler/queues/buildqueue.py
@@ -38,7 +38,7 @@ class BuildQueue(Queue):
         super().__init__(*args, **kwargs)
         self._tried = set()
 
-    def enqueue(self, elts):
+    def enqueue(self, elts, task=None):
         to_queue = []
 
         for element in elts:
@@ -64,7 +64,7 @@ class BuildQueue(Queue):
             element_name = element._get_full_name()
             self._task_group.add_failed_task(element_name)
 
-        return super().enqueue(to_queue)
+        return super().enqueue(to_queue, task)
 
     def get_process_func(self):
         return BuildQueue._assemble_element

--- a/src/buildstream/_scheduler/queues/queue.py
+++ b/src/buildstream/_scheduler/queues/queue.py
@@ -175,12 +175,15 @@ class Queue:
     # Args:
     #    elts (list): A list of Elements
     #
-    def enqueue(self, elts):
+    def enqueue(self, elts, task=None):
         if not elts:
             return
 
         # Obtain immediate element status
         for elt in elts:
+            if task:
+                task.add_current_progress()
+
             self._enqueue_element(elt)
 
     # dequeue()

--- a/src/buildstream/_stream.py
+++ b/src/buildstream/_stream.py
@@ -1321,7 +1321,11 @@ class Stream:
     #
     def _enqueue_plan(self, plan, *, queue=None):
         queue = queue or self.queues[0]
-        queue.enqueue(plan)
+
+        with self._context.messenger.simple_task("Preparing work plan") as task:
+            task.set_maximum_progress(len(plan))
+            queue.enqueue(plan, task)
+
         self.session_elements += plan
 
     # _failure_retry()


### PR DESCRIPTION
[See original merge request on GitLab](https://gitlab.com/BuildStream/buildstream/-/merge_requests/1840)
In GitLab by [[Gitlab user @BenjaminSchubert]](https://gitlab.com/BenjaminSchubert) on Mar 26, 2020, 09:12

## Description

This addresses part of #1261.


## Benchmarking

**NOTE** It seems my machine was quite noisy at that moment.

- Finished in: 88 mins, 30 secs                                                                                                                                    
- Number of builders: [4, 8, 12]                                                                                                                                   
- Target files: base-files/base-files.bst
- Number of runs: 3
- Number of warmups: 1
- Python versions: py37

| action                 | python_version   | commit                                   |   median time (secs) | mean time (secs) ± std   |
|:-----------------------|:-----------------|:-----------------------------------------|---------------------:|:-------------------------|
| build - 12             | py37             | bschubert/notify-prepare-plan - fbeb1490 |               175.57 | 175.31 ± 0.67            |
|                        | py37             | master - 3408afbf                        |               177.58 | 178.10 ± 2.16            |
| build - 4              | py37             | bschubert/notify-prepare-plan - fbeb1490 |               176.15 | 175.84 ± 1.13            |
|                        | py37             | master - 3408afbf                        |               176    | 176.41 ± 0.89            |
| build - 8              | py37             | bschubert/notify-prepare-plan - fbeb1490 |               174.11 | 174.19 ± 0.82            |
|                        | py37             | master - 3408afbf                        |               175.65 | 175.76 ± 0.24            |
| show                   | py37             | bschubert/notify-prepare-plan - fbeb1490 |                 5.49 | 5.53 ± 0.23              |
|                        | py37             | master - 3408afbf                        |                 4.87 | 4.87 ± 0.02              |
| show - cached          | py37             | bschubert/notify-prepare-plan - fbeb1490 |                 9.46 | 9.47 ± 0.04              |
|                        | py37             | master - 3408afbf                        |                 9.52 | 9.52 ± 0.08              |
| show - sources fetched | py37             | bschubert/notify-prepare-plan - fbeb1490 |                 7.36 | 7.37 ± 0.07              |
|                        | py37             | master - 3408afbf                        |                 7.18 | 7.12 ± 0.13              |
| source fetch           | py37             | bschubert/notify-prepare-plan - fbeb1490 |                78.45 | 78.43 ± 0.27             |
|                        | py37             | master - 3408afbf                        |                92.87 | 93.11 ± 1.09             |

| action                 | python_version   | commit                                   |   median max memory (MB) | mean max memory (MB) ± std   |
|:-----------------------|:-----------------|:-----------------------------------------|-------------------------:|:-----------------------------|
| build - 12             | py37             | bschubert/notify-prepare-plan - fbeb1490 |                  214.734 | 214.81 ± 0.15                |
|                        | py37             | master - 3408afbf                        |                  217.57  | 217.68 ± 0.21                |
| build - 4              | py37             | bschubert/notify-prepare-plan - fbeb1490 |                  214.969 | 214.99 ± 0.19                |
|                        | py37             | master - 3408afbf                        |                  217.641 | 217.66 ± 0.14                |
| build - 8              | py37             | bschubert/notify-prepare-plan - fbeb1490 |                  214.883 | 214.83 ± 0.12                |
|                        | py37             | master - 3408afbf                        |                  217.66  | 217.74 ± 0.20                |
| show                   | py37             | bschubert/notify-prepare-plan - fbeb1490 |                  186.43  | 186.35 ± 0.19                |
|                        | py37             | master - 3408afbf                        |                  189.371 | 189.24 ± 0.28                |
| show - cached          | py37             | bschubert/notify-prepare-plan - fbeb1490 |                  213.973 | 213.98 ± 0.07                |
|                        | py37             | master - 3408afbf                        |                  216.594 | 216.68 ± 0.15                |
| show - sources fetched | py37             | bschubert/notify-prepare-plan - fbeb1490 |                  184.758 | 184.70 ± 0.25                |
|                        | py37             | master - 3408afbf                        |                  187.57  | 187.46 ± 0.28                |
| source fetch           | py37             | bschubert/notify-prepare-plan - fbeb1490 |                  187.48  | 187.53 ± 0.13                |
|                        | py37             | master - 3408afbf                        |                  190.574 | 190.58 ± 0.13                |

There were 3 runs of each command.
----