### PR TITLE
Bump coverage requirement to something >= 5.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -86,15 +86,6 @@ tests-centos-7.6:
 tests-python-3.8-buster:
   image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-python:3.8-buster-${DOCKER_IMAGE_VERSION}
   <<: *tests
-  variables:
-    # This particular testsuite image has both Python 3.7 and Python 3.8 so we
-    # need to explicitly force the 3.8 environment.
-    # Once Python 3.8 is available in distros, we should switch to such an
-
-    # Our testsuite has issues with coverage on Python 3.8 so disable coverage
-    # in the meantime. For more details, see
-    # https://gitlab.com/BuildStream/buildstream/issues/1173.
-    TOXENV: py38-nocover,py38-plugins-nocover
 
 # Test the master version of some external plugins
 tests-plugins-master:

--- a/requirements/cov-requirements.in
+++ b/requirements/cov-requirements.in
@@ -1,3 +1,3 @@
-coverage == 4.4.0
+coverage >= 5.0
 pytest-cov >= 2.5.0
 Cython

--- a/requirements/cov-requirements.txt
+++ b/requirements/cov-requirements.txt
@@ -1,4 +1,4 @@
-coverage==4.4
+coverage==5.0.4
 pytest-cov==2.8.1
 Cython==0.29.14
 ## The following requirements were added by pip freeze:


### PR DESCRIPTION
[See original merge request on GitLab](https://gitlab.com/BuildStream/buildstream/-/merge_requests/1856)
In GitLab by [[Gitlab user @jjardon]](https://gitlab.com/jjardon) on Apr 5, 2020, 11:14

From https://coverage.readthedocs.io/en/coverage-5.0.4/changes.html#changes:

- Only 5.0a2 pass all python3.8 tests
- Multiprocessing support in Python 3.8 was fixed in 5.0a6


Fixes #1173 