### PR TITLE
WIP: Allow junctions to inject dependencies from current project to junctioned one

### DIFF
--- a/src/buildstream/_loader/loader.py
+++ b/src/buildstream/_loader/loader.py
@@ -311,6 +311,10 @@ class Loader:
         if filename in self._elements:
             return self._elements[filename]
 
+        if self.project.junction and filename in self.project.junction.replacements:
+            replacement = self.project.junction.replacements.get_str(filename)
+            return self._parent._load_file(replacement, rewritable, ticker, provenance)
+
         # Call the ticker
         if ticker:
             ticker(filename)
@@ -339,6 +343,9 @@ class Loader:
                         dep.junction, rewritable=rewritable, ticker=ticker, provenance=dep.provenance
                     )
                     dep_element = loader._load_file(dep.name, rewritable, ticker, dep.provenance)
+                elif self.project.junction and dep.name in self.project.junction.replacements:
+                    replacement = self.project.junction.replacements.get_str(dep.name)
+                    dep_element = self._parent._load_file(replacement, rewritable, ticker, dep.provenance)
                 else:
                     dep_element = self._elements.get(dep.name)
 

--- a/src/buildstream/plugins/elements/junction.py
+++ b/src/buildstream/plugins/elements/junction.py
@@ -173,7 +173,9 @@ class JunctionElement(Element):
 
     def configure(self, node):
 
-        node.validate_keys(["path", "options", "target", "cache-junction-elements", "ignore-junction-remotes"])
+        node.validate_keys(
+            ["path", "options", "target", "cache-junction-elements", "ignore-junction-remotes", "replacements"]
+        )
 
         self.path = node.get_str("path", default="")
         self.options = node.get_mapping("options", default={})
@@ -182,6 +184,7 @@ class JunctionElement(Element):
         self.target_junction = None
         self.cache_junction_elements = node.get_bool("cache-junction-elements", default=False)
         self.ignore_junction_remotes = node.get_bool("ignore-junction-remotes", default=False)
+        self.replacements = node.get_mapping("replacements", default={})
 
     def preflight(self):
         # "target" cannot be used in conjunction with:

--- a/tests/format/junctions.py
+++ b/tests/format/junctions.py
@@ -471,3 +471,35 @@ def test_junction_show(cli, tmpdir, datafiles):
 
     # Show, assert that it says junction
     assert cli.get_element_state(project, "base.bst") == "junction"
+
+
+@pytest.mark.datafiles(DATA_DIR)
+def test_replacements(cli, tmpdir, datafiles):
+    project = os.path.join(str(datafiles), "replacements")
+    copy_subprojects(project, datafiles, ["replacements-base"])
+    checkoutdir = os.path.join(str(tmpdir), "checkout")
+
+    # Build, checkout
+    result = cli.run(project=project, args=["build", "stack.bst"])
+    result.assert_success()
+    result = cli.run(project=project, args=["artifact", "checkout", "stack.bst", "--directory", checkoutdir])
+    result.assert_success()
+
+    assert os.path.exists(os.path.join(checkoutdir, "destination/injected.txt"))
+    assert not os.path.exists(os.path.join(checkoutdir, "original.txt"))
+
+
+@pytest.mark.datafiles(DATA_DIR)
+def test_replacements_top_element(cli, tmpdir, datafiles):
+    project = os.path.join(str(datafiles), "replacements")
+    copy_subprojects(project, datafiles, ["replacements-base"])
+    checkoutdir = os.path.join(str(tmpdir), "checkout")
+
+    # Build, checkout
+    result = cli.run(project=project, args=["build", "base.bst:a.bst"])
+    result.assert_success()
+    result = cli.run(project=project, args=["artifact", "checkout", "base.bst:a.bst", "--directory", checkoutdir])
+    result.assert_success()
+
+    assert os.path.exists(os.path.join(checkoutdir, "destination/injected.txt"))
+    assert not os.path.exists(os.path.join(checkoutdir, "original.txt"))

--- a/tests/format/junctions/replacements-base/a.bst
+++ b/tests/format/junctions/replacements-base/a.bst
@@ -1,0 +1,4 @@
+kind: import
+sources:
+- kind: local
+  path: original.txt

--- a/tests/format/junctions/replacements-base/compose.bst
+++ b/tests/format/junctions/replacements-base/compose.bst
@@ -1,0 +1,3 @@
+kind: compose
+build-depends:
+- a.bst

--- a/tests/format/junctions/replacements-base/original.txt
+++ b/tests/format/junctions/replacements-base/original.txt
@@ -1,0 +1,1 @@
+Original

--- a/tests/format/junctions/replacements-base/project.conf
+++ b/tests/format/junctions/replacements-base/project.conf
@@ -1,0 +1,2 @@
+name: replacements-base
+min-version: 2.0

--- a/tests/format/junctions/replacements/base.bst
+++ b/tests/format/junctions/replacements/base.bst
@@ -1,0 +1,7 @@
+kind: junction
+config:
+  replacements:
+    a.bst: injected.bst
+sources:
+- kind: local
+  path: replacements-base

--- a/tests/format/junctions/replacements/injected.bst
+++ b/tests/format/junctions/replacements/injected.bst
@@ -1,0 +1,6 @@
+kind: import
+config:
+  target: "%{dest}"
+sources:
+- kind: local
+  path: injected.txt

--- a/tests/format/junctions/replacements/injected.txt
+++ b/tests/format/junctions/replacements/injected.txt
@@ -1,0 +1,1 @@
+Injected

--- a/tests/format/junctions/replacements/project.conf
+++ b/tests/format/junctions/replacements/project.conf
@@ -1,0 +1,6 @@
+name: replacements
+min-version: 2.0
+
+variables:
+  # This variable is not defined in the junctioned project
+  dest: "/destination"

--- a/tests/format/junctions/replacements/stack.bst
+++ b/tests/format/junctions/replacements/stack.bst
@@ -1,0 +1,3 @@
+kind: stack
+runtime-depends:
+- base.bst:compose.bst


### PR DESCRIPTION
[See original merge request on GitLab](https://gitlab.com/BuildStream/buildstream/-/merge_requests/1913)
In GitLab by [[Gitlab user @valentindavid]](https://gitlab.com/valentindavid) on May 10, 2020, 16:13

There are cases where downstream projects want to overwrite upstream
elements.

So far, either the downstream project just allows overlaps and hopes
that ABI is compatible. There are also files left from original
elements when not overwritten.

Or downstream adds an "overlay" with local source to the
junctions. However on the latter, elements in the overlay are
considered as part of upstream, which means in cannot depend on
element outside of upstream (unless cyclic junction maybe?).

Here we add a feature to junctions to allow injecting elements from
current project to junctions.

This is useful for example in the case of GNOME SDK needing to override
GLib, GObjectIntrospection, libsoup, etc. from Freedesktop SDK.

The backported branch to 1.4 !1914 was tested on GNOME SDK: https://gitlab.gnome.org/GNOME/gnome-build-meta/-/merge_requests/658