### PR TITLE
Draft: Use bb-remote-asset alongside buildgrid for remote execution tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -185,7 +185,8 @@ tests-remote-execution:
   variables:
     <<: *docker-variables
     COMPOSE_MANIFEST: .gitlab-ci/buildgrid-remote-execution.yml # < *remote-test
-    ARTIFACT_CACHE_SERVICE: http://docker:50052
+    ARTIFACT_INDEX_SERVICE: http://docker:8979
+    ARTIFACT_STORAGE_SERVICE: http://docker:50052
     REMOTE_EXECUTION_SERVICE: http://docker:50051
     SOURCE_CACHE_SERVICE: http://docker:50052
     PYTEST_ARGS: "--color=yes --remote-execution"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -205,8 +205,8 @@ tests-bb-remote-cache:
   variables:
     <<: *docker-variables
     COMPOSE_MANIFEST: .gitlab-ci/buildbarn-remote-cache.yml # < *remote-test
-    ARTIFACT_INDEX_SERVICE: http://docker:7981
-    ARTIFACT_STORAGE_SERVICE: http://docker:7982
+    ARTIFACT_INDEX_SERVICE: http://docker:8979
+    ARTIFACT_STORAGE_SERVICE: http://docker:8980
     PYTEST_ARGS: "--color=yes --remote-cache"
 
 tests-no-usedevelop:

--- a/.gitlab-ci/buildbarn-remote-cache.yml
+++ b/.gitlab-ci/buildbarn-remote-cache.yml
@@ -27,9 +27,9 @@ services:
     command: /config/asset.jsonnet
     restart: unless-stopped
     expose:
-    - "7981"
+    - 8979
     ports:
-    - "7981:7981"
+    - "8979:8979"
     volumes:
     - type: volume
       source: assets
@@ -43,9 +43,9 @@ services:
     command: /config/storage.jsonnet
     restart: unless-stopped
     expose:
-    - "7982"
+    - 8980
     ports:
-    - "7982:7982"
+    - "8980:8980"
     volumes:
     - type: volume
       source: cas

--- a/.gitlab-ci/buildgrid-remote-execution.yml
+++ b/.gitlab-ci/buildgrid-remote-execution.yml
@@ -59,9 +59,23 @@ services:
     networks:
       - grid
 
+  bb-asset:
+    image: buildbarn/bb-remote-asset:20200828T155422Z-9226c9e
+    command: /config/asset.jsonnet
+    restart: unless-stopped
+    ports:
+    - 8979:8979
+    - 7981:7981
+    volumes:
+    - assets:/storage
+    - ./config/:/config
+    networks:
+    - grid
+
 networks:
   grid:
     driver: bridge
 
 volumes:
   cache:
+  assets:

--- a/.gitlab-ci/config/asset.jsonnet
+++ b/.gitlab-ci/config/asset.jsonnet
@@ -23,7 +23,7 @@
   },
   httpListenAddress: ':1111',
   grpcServers: [{
-    listenAddresses: [':7981'],
+    listenAddresses: [':8979'],
     authenticationPolicy: { allow: {} },
   }],
   allowUpdatesForInstances: [''],

--- a/tests/remoteexecution/buildtree.py
+++ b/tests/remoteexecution/buildtree.py
@@ -37,34 +37,33 @@ def test_buildtree_remote(cli, tmpdir, datafiles):
     element_name = "build-shell/buildtree.bst"
     share_path = os.path.join(str(tmpdir), "share")
 
-    services = cli.ensure_services()
-    assert set(services) == set(["action-cache", "execution", "storage"])
+    services = cli.ensure_services(artifacts=True)
+    assert set(services) == set(["action-cache", "execution", "storage", "artifact-cache"])
 
-    with create_artifact_share(share_path) as share:
-        cli.configure({"artifacts": {"url": share.repo, "push": True}, "cache": {"pull-buildtrees": False}})
+    cli.configure("cache": {"pull-buildtrees": False}})
 
-        res = cli.run(project=project, args=["--cache-buildtrees", "always", "build", element_name])
-        res.assert_success()
+    res = cli.run(project=project, args=["--cache-buildtrees", "always", "build", element_name])
+    res.assert_success()
 
-        # remove local cache
-        shutil.rmtree(os.path.join(str(tmpdir), "cache", "cas"))
-        shutil.rmtree(os.path.join(str(tmpdir), "cache", "artifacts"))
+    # remove local cache
+    shutil.rmtree(os.path.join(str(tmpdir), "cache", "cas"))
+    shutil.rmtree(os.path.join(str(tmpdir), "cache", "artifacts"))
 
-        # pull without buildtree
-        res = cli.run(project=project, args=["artifact", "pull", "--deps", "all", element_name])
-        res.assert_success()
+    # pull without buildtree
+    res = cli.run(project=project, args=["artifact", "pull", "--deps", "all", element_name])
+    res.assert_success()
 
-        # check shell doesn't work
-        res = cli.run(project=project, args=["shell", "--build", element_name, "--", "cat", "test"])
-        res.assert_shell_error()
+    # check shell doesn't work
+    res = cli.run(project=project, args=["shell", "--build", element_name, "--", "cat", "test"])
+    res.assert_shell_error()
 
-        # pull with buildtree
-        res = cli.run(project=project, args=["--pull-buildtrees", "artifact", "pull", "--deps", "all", element_name])
-        res.assert_success()
+    # pull with buildtree
+    res = cli.run(project=project, args=["--pull-buildtrees", "artifact", "pull", "--deps", "all", element_name])
+    res.assert_success()
 
-        # check it works this time
-        res = cli.run(
-            project=project, args=["shell", "--build", element_name, "--use-buildtree", "always", "--", "cat", "test"]
-        )
-        res.assert_success()
-        assert "Hi" in res.output
+    # check it works this time
+    res = cli.run(
+        project=project, args=["shell", "--build", element_name, "--use-buildtree", "always", "--", "cat", "test"]
+    )
+    res.assert_success()
+    assert "Hi" in res.output


### PR DESCRIPTION
[See original merge request on GitLab](https://gitlab.com/BuildStream/buildstream/-/merge_requests/2058)
In GitLab by [[Gitlab user @Qinusty]](https://gitlab.com/Qinusty) on Sep 4, 2020, 15:15

## Description

[//]: # (Provide a description of the MR including what it resolves)



[//]: # (Proposed changes)

Changes proposed in this merge request:
* Change 1
* Change 2
* Change 3

[//]: # (Task or bug number that this MR solves preceded by #)

This merge request,  when approved, will close: 

----