### PR TITLE
Restore task element name / element name distinction in UI

### DIFF
--- a/src/buildstream/_artifactcache.py
+++ b/src/buildstream/_artifactcache.py
@@ -121,7 +121,7 @@ class ArtifactCache(AssetCache):
     #
     def push(self, element, artifact):
         project = element._get_project()
-        display_key = element._get_brief_display_key()
+        display_key = element._get_display_key()
 
         index_remotes = [r for r in self._index_remotes[project] if r.push]
         storage_remotes = [r for r in self._storage_remotes[project] if r.push]
@@ -135,15 +135,13 @@ class ArtifactCache(AssetCache):
         # can perform file checks on their end
         for remote in storage_remotes:
             remote.init()
-            element.status("Pushing data from artifact {} -> {}".format(display_key, remote))
+            element.status("Pushing data from artifact {} -> {}".format(display_key.brief, remote))
 
             if self._push_artifact_blobs(artifact, artifact_digest, remote):
-                element.info("Pushed data from artifact {} -> {}".format(display_key, remote))
+                element.info("Pushed data from artifact {} -> {}".format(display_key.brief, remote))
             else:
                 element.info(
-                    "Remote ({}) already has all data of artifact {} cached".format(
-                        remote, element._get_brief_display_key()
-                    )
+                    "Remote ({}) already has all data of artifact {} cached".format(remote, display_key.brief)
                 )
 
         for remote in index_remotes:
@@ -154,9 +152,7 @@ class ArtifactCache(AssetCache):
                 element.info("Pushed artifact {} -> {}".format(display_key, remote))
                 pushed = True
             else:
-                element.info(
-                    "Remote ({}) already has artifact {} cached".format(remote, element._get_brief_display_key())
-                )
+                element.info("Remote ({}) already has artifact {} cached".format(remote, display_key.brief))
 
         return pushed
 

--- a/src/buildstream/_elementsources.py
+++ b/src/buildstream/_elementsources.py
@@ -279,7 +279,7 @@ class ElementSources:
     def get_cache_key(self):
         return self._cache_key
 
-    # _get_brief_display_key()
+    # get_brief_display_key()
     #
     # Returns an abbreviated cache key for display purposes
     #

--- a/src/buildstream/_frontend/app.py
+++ b/src/buildstream/_frontend/app.py
@@ -447,19 +447,18 @@ class App:
     #
     # Args:
     #    element_name (str): The element's full name
-    #    element_key (tuple): The element's display key
+    #    display_key (_DisplayKey): The element's display key
     #
     # Returns:
     #    (str): The formatted prompt to display in the shell
     #
-    def shell_prompt(self, element_name, element_key):
-
-        _, key, dim = element_key
+    def shell_prompt(self, element_name, display_key):
 
         if self.colors:
+            dim_key = not display_key.strict
             prompt = (
                 self._format_profile.fmt("[")
-                + self._content_profile.fmt(key, dim=dim)
+                + self._content_profile.fmt(display_key.brief, dim=dim_key)
                 + self._format_profile.fmt("@")
                 + self._content_profile.fmt(element_name)
                 + self._format_profile.fmt(":")
@@ -468,7 +467,7 @@ class App:
                 + " "
             )
         else:
-            prompt = "[{}@{}:${{PWD}}]$ ".format(key, element_name)
+            prompt = "[{}@{}:${{PWD}}]$ ".format(display_key.brief, element_name)
 
         return prompt
 
@@ -703,8 +702,8 @@ class App:
                 if choice == "shell":
                     click.echo("\nDropping into an interactive shell in the failed build sandbox\n", err=True)
                     try:
-                        unique_id, element_key = element
-                        prompt = self.shell_prompt(full_name, element_key)
+                        unique_id, display_key = element
+                        prompt = self.shell_prompt(full_name, display_key)
                         self.stream.shell(
                             None, _Scope.BUILD, prompt, isolate=True, usebuildtree="always", unique_id=unique_id
                         )

--- a/src/buildstream/_frontend/cli.py
+++ b/src/buildstream/_frontend/cli.py
@@ -637,9 +637,9 @@ def shell(app, element, mount, isolate, build_, cli_buildtree, pull_, command):
         pull_dependencies = elements[:-1] if pull_ else None
 
         element_name = element._get_full_name()
-        element_key = element._get_display_key()
+        display_key = element._get_display_key()
 
-        prompt = app.shell_prompt(element_name, element_key)
+        prompt = app.shell_prompt(element_name, display_key)
         mounts = [HostMount(path, host_path) for host_path, path in mount]
 
         artifact_is_cached = element._cached()

--- a/src/buildstream/_frontend/widget.py
+++ b/src/buildstream/_frontend/widget.py
@@ -170,7 +170,8 @@ class TypeName(Widget):
 class ElementName(Widget):
     def render(self, message):
         action_name = message.action_name
-        element_name = message.element_name
+        element_name = message.task_element_name or message.element_name
+
         if element_name is not None:
             name = "{: <30}".format(element_name)
         else:
@@ -211,9 +212,10 @@ class CacheKey(Widget):
 
         dim = False
         key = " " * self._key_length
-        if message.element_key:
-            key = message.element_key.brief
-            dim = not message.element_key.strict
+        element_key = message.task_element_key or message.element_key
+        if element_key:
+            key = element_key.brief
+            dim = not element_key.strict
 
         if message.message_type in ERROR_MESSAGES:
             text = self._err_profile.fmt(key)

--- a/src/buildstream/_frontend/widget.py
+++ b/src/buildstream/_frontend/widget.py
@@ -209,15 +209,16 @@ class CacheKey(Widget):
         if message.element_name is None:
             return " " * self._key_length
 
-        missing = False
+        dim = False
         key = " " * self._key_length
         if message.element_key:
-            _, key, missing = message.element_key
+            key = message.element_key.brief
+            dim = not message.element_key.strict
 
         if message.message_type in ERROR_MESSAGES:
             text = self._err_profile.fmt(key)
         else:
-            text = self.content_profile.fmt(key, dim=missing)
+            text = self.content_profile.fmt(key, dim=dim)
 
         return text
 
@@ -340,11 +341,12 @@ class LogLine(Widget):
         for element in dependencies:
             line = format_
 
-            full_key, cache_key, dim_keys = element._get_display_key()
+            key = element._get_display_key()
+            dim_keys = not key.strict
 
             line = p.fmt_subst(line, "name", element._get_full_name(), fg="blue", bold=True)
-            line = p.fmt_subst(line, "key", cache_key, fg="yellow", dim=dim_keys)
-            line = p.fmt_subst(line, "full-key", full_key, fg="yellow", dim=dim_keys)
+            line = p.fmt_subst(line, "key", key.brief, fg="yellow", dim=dim_keys)
+            line = p.fmt_subst(line, "full-key", key.full, fg="yellow", dim=dim_keys)
 
             try:
                 if not element._has_all_sources_resolved():

--- a/src/buildstream/_message.py
+++ b/src/buildstream/_message.py
@@ -52,6 +52,8 @@ class Message:
         message_type,
         message,
         *,
+        task_element_name=None,
+        task_element_key=None,
         element_name=None,
         element_key=None,
         detail=None,
@@ -63,8 +65,10 @@ class Message:
     ):
         self.message_type = message_type  # Message type
         self.message = message  # The message string
-        self.element_name = element_name  # The instance element name of the issuing plugin
-        self.element_key = element_key  # The display key of the issuing plugin element
+        self.task_element_name = task_element_name  # The name of the issuing task element
+        self.task_element_key = task_element_key  # The DisplayKey of the issuing task element
+        self.element_name = element_name  # The name of the issuing element
+        self.element_key = element_key  # The DisplayKey of the issuing element
         self.detail = detail  # An additional detail string
         self.action_name = action_name  # Name of the task queue (fetch, refresh, build, etc)
         self.elapsed = elapsed  # The elapsed time, in timed messages

--- a/src/buildstream/_messenger.py
+++ b/src/buildstream/_messenger.py
@@ -154,16 +154,16 @@ class Messenger:
     #
     # Args:
     #    activity_name (str): The name of the activity
-    #    element_name (str): Optionally, the element full name of the plugin related to the message
     #    detail (str): An optional detailed message, can be multiline output
-    #    silent_nested (bool): If True, all but _message.unconditional_messages are silenced
+    #    silent_nested (bool): If True, all nested messages are silenced except for unconditionaly ones
+    #    kwargs: Remaining Message() constructor keyword arguments.
     #
     @contextmanager
-    def timed_activity(self, activity_name, *, element_name=None, detail=None, silent_nested=False):
+    def timed_activity(self, activity_name, *, detail=None, silent_nested=False, **kwargs):
         with self.timed_suspendable() as timedata:
             try:
                 # Push activity depth for status messages
-                message = Message(MessageType.START, activity_name, detail=detail, element_name=element_name)
+                message = Message(MessageType.START, activity_name, detail=detail, **kwargs)
                 self.message(message)
                 with self.silence(actually_silence=silent_nested):
                     yield
@@ -172,12 +172,12 @@ class Messenger:
                 # Note the failure in status messages and reraise, the scheduler
                 # expects an error when there is an error.
                 elapsed = datetime.datetime.now() - timedata.start_time
-                message = Message(MessageType.FAIL, activity_name, elapsed=elapsed, element_name=element_name)
+                message = Message(MessageType.FAIL, activity_name, elapsed=elapsed, **kwargs)
                 self.message(message)
                 raise
 
             elapsed = datetime.datetime.now() - timedata.start_time
-            message = Message(MessageType.SUCCESS, activity_name, elapsed=elapsed, element_name=element_name)
+            message = Message(MessageType.SUCCESS, activity_name, elapsed=elapsed, **kwargs)
             self.message(message)
 
     # simple_task()
@@ -186,30 +186,31 @@ class Messenger:
     #
     # Args:
     #    activity_name (str): The name of the activity
-    #    element_name (str): Optionally, the element full name of the plugin related to the message
-    #    full_name (str): Optionally, the distinguishing name of the activity, e.g. element name
-    #    silent_nested (bool): If True, all but _message.unconditional_messages are silenced
+    #    task_name (str): Optionally, the task name for the frontend during this task
+    #    detail (str): An optional detailed message, can be multiline output
+    #    silent_nested (bool): If True, all nested messages are silenced except for unconditionaly ones
+    #    kwargs: Remaining Message() constructor keyword arguments.
     #
     # Yields:
     #    Task: A Task object that represents this activity, principally used to report progress
     #
     @contextmanager
-    def simple_task(self, activity_name, *, element_name=None, full_name=None, silent_nested=False):
+    def simple_task(self, activity_name, *, task_name=None, detail=None, silent_nested=False, **kwargs):
         # Bypass use of State when none exists (e.g. tests)
         if not self._state:
-            with self.timed_activity(activity_name, element_name=element_name, silent_nested=silent_nested):
+            with self.timed_activity(activity_name, detail=detail, silent_nested=silent_nested, **kwargs):
                 yield
             return
 
-        if not full_name:
-            full_name = activity_name
+        if not task_name:
+            task_name = activity_name
 
         with self.timed_suspendable() as timedata:
             try:
-                message = Message(MessageType.START, activity_name, element_name=element_name)
+                message = Message(MessageType.START, activity_name, detail=detail, **kwargs)
                 self.message(message)
 
-                task = self._state.add_task(full_name, activity_name, full_name)
+                task = self._state.add_task(task_name, activity_name, task_name)
                 task.set_render_cb(self._render_status)
                 self._active_simple_tasks += 1
                 if not self._next_render:
@@ -220,11 +221,11 @@ class Messenger:
 
             except BstError:
                 elapsed = datetime.datetime.now() - timedata.start_time
-                message = Message(MessageType.FAIL, activity_name, elapsed=elapsed, element_name=element_name)
+                message = Message(MessageType.FAIL, activity_name, elapsed=elapsed, **kwargs)
                 self.message(message)
                 raise
             finally:
-                self._state.remove_task(full_name)
+                self._state.remove_task(task_name)
                 self._active_simple_tasks -= 1
                 if self._active_simple_tasks == 0:
                     self._next_render = None
@@ -237,9 +238,7 @@ class Messenger:
                     detail = "{} of {} subtasks processed".format(task.current_progress, task.maximum_progress)
                 else:
                     detail = "{} subtasks processed".format(task.current_progress)
-            message = Message(
-                MessageType.SUCCESS, activity_name, elapsed=elapsed, detail=detail, element_name=element_name
-            )
+            message = Message(MessageType.SUCCESS, activity_name, elapsed=elapsed, detail=detail, **kwargs)
             self.message(message)
 
     # recorded_messages()

--- a/src/buildstream/_messenger.py
+++ b/src/buildstream/_messenger.py
@@ -370,7 +370,12 @@ class Messenger:
         template = "[{timecode: <8}] {type: <7}"
 
         # If this message is associated with an element or source plugin, print the
-        # full element name of the instance.
+        # full element name and key for the instance.
+        element_key = ""
+        if message.element_key:
+            template += " [{element_key}]"
+            element_key = message.element_key.brief
+
         element_name = ""
         if message.element_name:
             template += " {element_name}"
@@ -392,6 +397,7 @@ class Messenger:
 
         text = template.format(
             timecode=timecode,
+            element_key=element_key,
             element_name=element_name,
             type=message.message_type.upper(),
             message=message.message,

--- a/src/buildstream/_scheduler/jobs/job.py
+++ b/src/buildstream/_scheduler/jobs/job.py
@@ -140,8 +140,8 @@ class Job:
         self._terminated = False  # Whether this job has been explicitly terminated
 
         self._logfile = logfile
-        self._message_element_name = None  # The plugin instance element name for messaging
-        self._message_element_key = None  # The element key for messaging
+        self._message_element_name = None  # The task-wide element name
+        self._message_element_key = None  # The task-wide element cache key
         self._element = None  # The Element() passed to the Job() constructor, if applicable
 
     # set_name()
@@ -299,23 +299,21 @@ class Job:
     # Logs a message, this will be logged in the task's logfile and
     # conditionally also be sent to the frontend.
     #
-    # XXX: Note no calls to message() currently override the default
-    #      name & key (previously unique_id), potential to be removed.
-    #
     # Args:
     #    message_type (MessageType): The type of message to send
     #    message (str): The message
     #    kwargs: Remaining Message() constructor arguments, note that you can
     #            override 'element_name' and 'element_key' this way.
     #
-    def message(self, message_type, message, element_name=None, element_key=None, **kwargs):
+    def message(self, message_type, message, **kwargs):
         kwargs["scheduler"] = True
-        # If default name & key values not provided, set as given job attributes
-        if element_name is None:
-            element_name = self._message_element_name
-        if element_key is None:
-            element_key = self._message_element_key
-        message = Message(message_type, message, element_name=element_name, element_key=element_key, **kwargs)
+        message = Message(
+            message_type,
+            message,
+            element_name=self._message_element_name,
+            element_key=self._message_element_key,
+            **kwargs
+        )
         self._messenger.message(message)
 
     # get_element()
@@ -557,9 +555,6 @@ class ChildJob:
     # Logs a message, this will be logged in the task's logfile and
     # conditionally also be sent to the frontend.
     #
-    # XXX: Note no calls to message() currently override the default
-    #      name & key (previously unique_id), potential to be removed.
-    #
     # Args:
     #    message_type (MessageType): The type of message to send
     #    message (str): The message
@@ -568,15 +563,16 @@ class ChildJob:
     #            for front end display if not already set or explicitly
     #            overriden here.
     #
-    def message(self, message_type, message, element_name=None, element_key=None, **kwargs):
+    def message(self, message_type, message, **kwargs):
         kwargs["scheduler"] = True
-        # If default name & key values not provided, set as given job attributes
-        if element_name is None:
-            element_name = self._message_element_name
-        if element_key is None:
-            element_key = self._message_element_key
         self._messenger.message(
-            Message(message_type, message, element_name=element_name, element_key=element_key, **kwargs)
+            Message(
+                message_type,
+                message,
+                element_name=self._message_element_name,
+                element_key=self._message_element_key,
+                **kwargs
+            )
         )
 
     #######################################################
@@ -790,17 +786,14 @@ class ChildJob:
     def _child_message_handler(self, message, is_silenced):
 
         message.action_name = self.action_name
-
-        # If no key has been set at this point, and the element job has
-        # a related key, set it. This is needed for messages going
-        # straight to the message handler from the child process.
-        if message.element_key is None and self._message_element_key:
-            message.element_key = self._message_element_key
+        message.task_element_name = self._message_element_name
+        message.task_element_key = self._message_element_key
 
         # Send to frontend if appropriate
         if is_silenced and (message.message_type not in unconditional_messages):
             return
 
+        # Don't bother propagating these to the frontend
         if message.message_type == MessageType.LOG:
             return
 

--- a/src/buildstream/_scheduler/jobs/job.py
+++ b/src/buildstream/_scheduler/jobs/job.py
@@ -289,7 +289,7 @@ class Job:
     # key for for the issuing message (if an element is related to the Job).
     #
     # Args:
-    #     element_key (tuple): The element_key tuple to be supplied to the Message() constructor
+    #     element_key (_DisplayKey): The element_key tuple to be supplied to the Message() constructor
     #
     def set_message_element_key(self, element_key):
         self._message_element_key = element_key

--- a/src/buildstream/_scheduler/queues/queue.py
+++ b/src/buildstream/_scheduler/queues/queue.py
@@ -356,9 +356,9 @@ class Queue:
 
     def _element_log_path(self, element):
         project = element._get_project()
-        key = element._get_display_key()[1]
+        key = element._get_display_key()
         action = self.action_name.lower()
-        logfile = "{key}-{action}".format(key=key, action=action)
+        logfile = "{key}-{action}".format(key=key.brief, action=action)
 
         return os.path.join(project.name, element.normal_name, logfile)
 

--- a/src/buildstream/element.py
+++ b/src/buildstream/element.py
@@ -103,7 +103,7 @@ from .plugin import Plugin
 from .sandbox import SandboxFlags, SandboxCommandError
 from .sandbox._config import SandboxConfig
 from .sandbox._sandboxremote import SandboxRemote
-from .types import _Scope, _CacheBuildTrees, _KeyStrength, OverlapAction
+from .types import _Scope, _CacheBuildTrees, _KeyStrength, OverlapAction, _DisplayKey
 from ._artifact import Artifact
 from ._elementproxy import ElementProxy
 from ._elementsources import ElementSources
@@ -1399,15 +1399,13 @@ class Element(Plugin):
     # Returns cache keys for display purposes
     #
     # Returns:
-    #    (str): A full hex digest cache key for this Element
-    #    (str): An abbreviated hex digest cache key for this Element
-    #    (bool): True if key should be shown as dim, False otherwise
+    #    (_DisplayKey): The display key
     #
     # Question marks are returned if information for the cache key is missing.
     #
     def _get_display_key(self):
         context = self._get_context()
-        dim_key = True
+        strict = False
 
         cache_key = self._get_cache_key()
 
@@ -1416,10 +1414,10 @@ class Element(Plugin):
         elif cache_key == self.__strict_cache_key:
             # Strong cache key used in this session matches cache key
             # that would be used in strict build mode
-            dim_key = False
+            strict = True
 
         length = min(len(cache_key), context.log_key_length)
-        return (cache_key, cache_key[0:length], dim_key)
+        return _DisplayKey(cache_key, cache_key[0:length], strict)
 
     # _get_brief_display_key()
     #
@@ -1431,8 +1429,7 @@ class Element(Plugin):
     # Question marks are returned if information for the cache key is missing.
     #
     def _get_brief_display_key(self):
-        _, display_key, _ = self._get_display_key()
-        return display_key
+        return self._get_display_key().brief
 
     # _tracking_done():
     #

--- a/src/buildstream/element.py
+++ b/src/buildstream/element.py
@@ -1022,7 +1022,7 @@ class Element(Plugin):
         # Time to use the artifact, check once more that it's there
         self.__assert_cached()
 
-        self.status("Staging {}/{}".format(self.name, self._get_brief_display_key()))
+        self.status("Staging {}/{}".format(self.name, self._get_display_key().brief))
         # Disable type checking since we can't easily tell mypy that
         # `self.__artifact` can't be None at this stage.
         files_vdir = self.__artifact.get_files()  # type: ignore
@@ -1418,18 +1418,6 @@ class Element(Plugin):
 
         length = min(len(cache_key), context.log_key_length)
         return _DisplayKey(cache_key, cache_key[0:length], strict)
-
-    # _get_brief_display_key()
-    #
-    # Returns an abbreviated cache key for display purposes
-    #
-    # Returns:
-    #    (str): An abbreviated hex digest cache key for this Element
-    #
-    # Question marks are returned if information for the cache key is missing.
-    #
-    def _get_brief_display_key(self):
-        return self._get_display_key().brief
 
     # _tracking_done():
     #
@@ -2682,7 +2670,7 @@ class Element(Plugin):
     # Raises an error if the artifact is not cached.
     #
     def __assert_cached(self):
-        assert self._cached(), "{}: Missing artifact {}".format(self, self._get_brief_display_key())
+        assert self._cached(), "{}: Missing artifact {}".format(self, self._get_display_key().brief)
 
     # __get_tainted():
     #

--- a/src/buildstream/element.py
+++ b/src/buildstream/element.py
@@ -2449,6 +2449,17 @@ class Element(Plugin):
             self.__whitelist_regex = re.compile(expression)
         return self.__whitelist_regex.match(os.path.join(os.sep, path))
 
+    # _get_message_kwargs()
+    #
+    # Override Plugin._get_message_kwargs so that we include the cache keys
+    # in any messages issued by this element
+    #
+    def _get_message_kwargs(self) -> dict:
+        return {
+            "element_name": self._get_full_name(),
+            "element_key": self._get_display_key(),
+        }
+
     #############################################################
     #                   Private Local Methods                   #
     #############################################################

--- a/src/buildstream/types.py
+++ b/src/buildstream/types.py
@@ -208,6 +208,24 @@ class _KeyStrength(FastEnum):
     WEAK = 2
 
 
+# _DisplayKey():
+#
+# The components of a cache key which need to be displayed
+#
+# This is a part of Message() so it needs to be a simple serializable object.
+#
+# Args:
+#    full (str): A full hex digest cache key for an Element
+#    brief (str): An abbreviated hex digest cache key for an Element
+#    strict (bool): Whether the key matches the key which would be used in strict mode
+#
+class _DisplayKey:
+    def __init__(self, full: str, brief: str, strict: bool):
+        self.full = full  # type: str
+        self.brief = brief  # type: str
+        self.strict = strict  # type: bool
+
+
 # _SchedulerErrorAction()
 #
 # Actions the scheduler can take on error

--- a/tests/frontend/artifact_log.py
+++ b/tests/frontend/artifact_log.py
@@ -19,6 +19,7 @@
 # pylint: disable=redefined-outer-name
 
 import os
+import re
 import pytest
 
 from buildstream.testing import cli  # pylint: disable=unused-import
@@ -88,9 +89,12 @@ def test_artifact_log_files(cli, datafiles):
     assert os.path.exists(import_bin)
 
     # Ensure the file contains the logs by checking for the LOG line
+    pattern = r"\[..:..:..\] LOG     \[.*\] target.bst"
     with open(target, "r") as f:
         data = f.read()
-        assert "LOG     target.bst" in data
+        assert len(re.findall(pattern, data, re.MULTILINE)) > 0
+
+    pattern = r"\[..:..:..\] LOG     \[.*\] import-bin.bst"
     with open(import_bin, "r") as f:
         data = f.read()
-        assert "LOG     import-bin.bst" in data
+        assert len(re.findall(pattern, data, re.MULTILINE)) > 0

--- a/tests/frontend/logging.py
+++ b/tests/frontend/logging.py
@@ -106,5 +106,5 @@ def test_failed_build_listing(cli, datafiles):
     # Note that if we mess up the 'element_name' of Messages, they won't be printed
     # with the name of the relevant element, e.g. 'testfail-1.bst'. Check that
     # they have the name as expected.
-    pattern = r"\[..:..:..\] FAILURE testfail-.\.bst: Staged artifacts do not provide command 'sh'"
+    pattern = r"\[..:..:..\] FAILURE \[.*\] testfail-.\.bst: Staged artifacts do not provide command 'sh'"
     assert len(re.findall(pattern, result.stderr, re.MULTILINE)) == 6  # each element should be matched twice.


### PR DESCRIPTION
[See original merge request on GitLab](https://gitlab.com/BuildStream/buildstream/-/merge_requests/2070)
In GitLab by [[Gitlab user @tristanvb]](https://gitlab.com/tristanvb) on Sep 21, 2020, 10:05


    This behavior has regressed a while back when introducing the messenger
    object in 0026e379 from merge request !1500.
    
    Main behavior change:
    
      - Messages in the master log always appear with the task element's
        element name and cache key, even if the element or plugin issuing
        the log line is not the primary task element.
    
      - Messages logged in the task specific log, retain the context of the
        element names and cache keys which are issuing the log lines.
    
    Changes include:
    
      * _message.py: Added the task element name & key members
    
      * _messenger.py: Log the element key as well if it is provided
    
      * _widget.py: Prefer the task name & key when logging, we fallback
        to the element name & key in case messages are being logged outside
        of any ongoing task (main process/context)
    
      * job.py: Unconditionally stamp messages with the task name & key
    
        Also removed some unused parameters here, clearing up an XXX comment
    
      * plugin.py: Make _message() internal so that element.py can override it
    
      * element.py: Override _message() so that we can add the issuing element's
        cache key to the message context.
    
    Fixes #1393