### PR TITLE
Get release and snapshot badge images from docs website

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,10 +1,10 @@
 About
 -----
 
-.. image:: https://buildstream.gitlab.io/buildstream/_static/release.svg
+.. image:: https://docs.buildstream.build/master/_static/release.svg
    :target: https://gitlab.com/BuildStream/buildstream/commits/bst-1
 
-.. image:: https://buildstream.gitlab.io/buildstream/_static/snapshot.svg
+.. image:: https://docs.buildstream.build/master/_static/snapshot.svg
    :target: https://gitlab.com/BuildStream/buildstream/commits/master
 
 .. image:: https://gitlab.com/BuildStream/buildstream/badges/master/pipeline.svg


### PR DESCRIPTION
[See original merge request on GitLab](https://gitlab.com/BuildStream/buildstream/-/merge_requests/2086)
In GitLab by [[Gitlab user @DouglasWinship]](https://gitlab.com/DouglasWinship) on Oct 12, 2020, 14:23

* get release badge image from: docs.buildstream.build/master/_static/release.svg
* get snapshot badge image from: docs.buildstream.build/master/_static/snapshot.svg